### PR TITLE
Enforcing the use of wrt and at functions in derivatives, gradient an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,107 @@
+# Change Log
+
+This file documents important changes to this project, which uses [Semantic Versioning](http://semver.org/).
+
+#[v0.5](https://github.com/autodiff/autodiff/releases/tag/v0.5.0) (June 17, 2019)
+[Full Changelog](https://github.com/autodiff/autodiff/compare/v0.5.0...v0.4.2)
+
+This release introduces a **BREAKING CHANGE**!
+
+From now on, methods `derivative`, `gradient`, and `jacobian` require the
+use of auxiliary functions `wrt` and the newly introduced one `at`.
+
+Examples:
+
+~~~c++
+// f = f(x)
+double dudx = derivative(f, wrt(x), at(x));
+~~~
+
+~~~c++
+// f = f(x, y, z)
+double dudx = derivative(f, wrt(x), at(x, y, z));
+double dudy = derivative(f, wrt(y), at(x, y, z));
+double dudz = derivative(f, wrt(z), at(x, y, z));
+~~~
+
+~~~c++
+// f = f(x), scalar function, where x is an Eigen vector
+VectorXd g = gradient(f, wrt(x), at(x));
+
+// Compuring gradient with respect to only some variables
+VectorXd gpartial = gradient(f, wrt(x.tail(5)), at(x));
+~~~
+
+~~~c++
+// F = F(x), vector function, where x is an Eigen vector
+MatrixXd J = jacobian(f, wrt(x), at(x));
+
+// F = F(x, p), vector function with params, where x and p are Eigen vectors
+MatrixXd Jx = jacobian(f, wrt(x), at(x, p));
+MatrixXd Jp = jacobian(f, wrt(p), at(x, p));
+
+// Compuring Jacobian with respect to only some variables
+MatrixXd Jpartial = jacobian(f, wrt(x.tail(5)), at(x));
+~~~
+
+This release also permits one to retrieve the evaluated value of function during
+a call to the methods `derivative`, `gradient`, and `jacobian`:
+
+~~~c++
+// f = f(x)
+dual u;
+double dudx = derivative(f, wrt(x), at(x), u);
+~~~
+
+~~~c++
+// f = f(x), scalar function, where x is an Eigen vector
+dual u;
+VectorXd g = gradient(f, wrt(x), at(x), u);
+~~~
+
+~~~c++
+// F = F(x), vector function, where x is an Eigen vector
+VectorXdual F;
+MatrixXd J = jacobian(f, wrt(x), at(x), F);
+~~~
+
+#[v0.4.2](https://github.com/autodiff/autodiff/releases/tag/v0.4.2) (Mar 28, 2019)
+[Full Changelog](https://github.com/autodiff/autodiff/compare/v0.4.2...v0.4.1)
+
+This is to force conda-forge to produce a new version (now 0.4.2) since the last
+one (0.4.1) did not work.
+
+#[v0.4.1](https://github.com/autodiff/autodiff/releases/tag/v0.4.1) (Mar 26, 2019)
+[Full Changelog](https://github.com/autodiff/autodiff/compare/v0.4.1...v0.4.0)
+
+This release fixes a bug in the computation of Jacobian matrices when the input
+and output vectors in a vector-valued function have different dimensions (see
+issue [#24](https://github.com/autodiff/autodiff/issues/24)).
+
+#[v0.4.0](https://github.com/autodiff/autodiff/releases/tag/v0.4.0) (Feb 20, 2019)
+[Full Changelog](https://github.com/autodiff/autodiff/compare/v0.4.0...v0.3.0)
+
+This release contains changes that enable autodiff to be successfully compiled
+in Linux, macOS, and Windows. Compilers tested were GCC 7, Clang 9, and Visual
+Studio 2017. Compilers should support C++17.
+
+#[v0.3.0](https://github.com/autodiff/autodiff/releases/tag/v0.3.0) (Feb 5, 2019)
+[Full Changelog](https://github.com/autodiff/autodiff/compare/v0.3.0...v0.2.0)
+
+This release improves the forward mode algorithm to compute derivatives of any
+order. It also introduces a proper website containing a more detailed
+documentation of autodiff library: https://autodiff.github.io
+
+#[v0.2.0](https://github.com/autodiff/autodiff/releases/tag/v0.2.0) (Jul 26, 2018)
+[Full Changelog](https://github.com/autodiff/autodiff/compare/v0.2.0...v0.1.0)
+
+This release permits higher order derivatives to be computed with
+`autodiff::gradx` function and it also enables the use of `autodiff::var` type
+with Eigen vector and matrix types.
+
+#[v0.1.0](https://github.com/autodiff/autodiff/releases/tag/v0.1.0) (Jul 19, 2018)
+[Full Changelog](https://github.com/autodiff/autodiff/compare/v3.6.0...v3.6.1)
+
+This is the first release of autodiff. Please note breaking changes might be
+introduced, but not something that would take you more than a few minutes to
+correct.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(CCache)
 
 # Name and details of the project
-project(autodiff VERSION 0.4.1 LANGUAGES CXX)
+project(autodiff VERSION 0.5.0 LANGUAGES CXX)
 
 # Include the cmake variables with values for installation directories
 include(GNUInstallDirs)

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ its derivatives *(∂u/∂x,  ∂u/∂y, ∂u/∂z)* with respect to the *input
 variables* *(x, y, z)*.
 
 Enabling forward automatic differentiation for the calculation of derivatives
-using **autodiff** is relatively simple. For our previous function *f*, we only
+using {{autodiff}} is relatively simple. For our previous function *f*, we only
 need to replace the floating-point type `double` to `autodiff::dual` for both
 input and output variables:
 
 ```c++
-dual f(dual x, dual y, dual z)
+dual f(const dual& x, const dual& y, const dual& z)
 {
     return (x + y + z) * exp(x * y * z);
 }
@@ -67,14 +67,16 @@ dual y = 2.0;
 dual z = 3.0;
 dual u = f(x, y, z);
 
-double dudx = derivative(f, wrt(x), x, y, z);
-double dudy = derivative(f, wrt(y), x, y, z);
-double dudz = derivative(f, wrt(z), x, y, z);
+double dudx = derivative(f, wrt(x), at(x, y, z));
+double dudy = derivative(f, wrt(y), at(x, y, z));
+double dudz = derivative(f, wrt(z), at(x, y, z));
 ```
 
-where the auxiliary function `autodiff::wrt`, which has the meaning of **with
-respect to**, is used to indicate which input variable *(x, y, z)* is the
-selected one to compute the partial derivative of *f*.
+The auxiliary function `autodiff::wrt`, an acronym for **with respect to**,
+is used to indicate which input variable *(x, y, z)* is the selected one to
+compute the partial derivative of *f*. The auxiliary function `autodiff::at`
+is used to indicate where (at which values of its parameters) the derivative
+of *f* is evaluated.
 
 ### Reverse mode
 
@@ -87,7 +89,7 @@ possible to compute the contribution of each branch on the derivatives of the
 output variable with respect to input variables.
 
 <img
-    src='docs/img/expression-tree-diagram.svg'
+    src='img/expression-tree-diagram.svg'
     style='max-width:100%;'
     title='Expression tree diagram.'>
 
@@ -99,7 +101,7 @@ simultaneously (e.g., in a single forward pass, *∂u/∂x*,  *∂u/∂y*, and *
 are evaluated together with *u*, in contrast with three forward passes, each
 one computing the individual derivatives).
 
-Similar as before, we can use **autodiff** to enable reverse automatic
+Similar as before, we can use {{autodiff}} to enable reverse automatic
 differentiation for our function *f* by simply replacing type `double` by
 `autodiff::var` as follows:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ need to replace the floating-point type `double` to `autodiff::dual` for both
 input and output variables:
 
 ```c++
-dual f(dual x, dual y, dual z)
+dual f(const dual& x, const dual& y, const dual& z)
 {
     return (x + y + z) * exp(x * y * z);
 }
@@ -72,14 +72,16 @@ dual y = 2.0;
 dual z = 3.0;
 dual u = f(x, y, z);
 
-double dudx = derivative(f, wrt(x), x, y, z);
-double dudy = derivative(f, wrt(y), x, y, z);
-double dudz = derivative(f, wrt(z), x, y, z);
+double dudx = derivative(f, wrt(x), at(x, y, z));
+double dudy = derivative(f, wrt(y), at(x, y, z));
+double dudz = derivative(f, wrt(z), at(x, y, z));
 ```
 
-where the auxiliary function `autodiff::wrt`, which has the meaning of **with
-respect to**, is used to indicate which input variable *(x, y, z)* is the
-selected one to compute the partial derivative of *f*.
+The auxiliary function `autodiff::wrt`, an acronym for **with respect to**,
+is used to indicate which input variable *(x, y, z)* is the selected one to
+compute the partial derivative of *f*. The auxiliary function `autodiff::at`
+is used to indicate where (at which values of its parameters) the derivative
+of *f* is evaluated.
 
 ### Reverse mode
 

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -18,9 +18,17 @@
 
 {{ inputcpp('examples/forward/example-forward-gradient-derivatives-using-eigen.cpp') }}
 
+### Gradient of a scalar function with parameters
+
+{{ inputcpp('examples/forward/example-forward-gradient-derivatives-using-eigen-with-parameters.cpp') }}
+
 ### Jacobian of a vector function
 
 {{ inputcpp('examples/forward/example-forward-jacobian-derivatives-using-eigen.cpp') }}
+
+### Jacobian of a vector function with parameters
+
+{{ inputcpp('examples/forward/example-forward-jacobian-derivatives-using-eigen-with-parameters.cpp') }}
 
 ### Higher-order derivatives of a multi-variable function
 

--- a/examples/forward/example-forward-gradient-derivatives-using-eigen-with-parameters.cpp
+++ b/examples/forward/example-forward-gradient-derivatives-using-eigen-with-parameters.cpp
@@ -1,0 +1,36 @@
+// C++ includes
+#include <iostream>
+using namespace std;
+
+// Eigen includes
+#include <eigen3/Eigen/Core>
+using namespace Eigen;
+
+// autodiff include
+#include <autodiff/forward.hpp>
+#include <autodiff/forward/eigen.hpp>
+using namespace autodiff;
+
+// The scalar function for which the gradient is needed
+dual f(const VectorXdual& x, const VectorXdual& p)
+{
+    return x.cwiseProduct(x).sum() * exp(p.sum()); // sum([x(i) * x(i) for i = 1:5]) * exp(sum(p))
+}
+
+int main()
+{
+    VectorXdual x(5);    // the input vector x with 5 variables
+    x << 1, 2, 3, 4, 5;  // x = [1, 2, 3, 4, 5]
+
+    VectorXdual p(3);    // the input parameter vector p with 3 variables
+    p << 1, 2, 3;        // p = [1, 2, 3]
+
+    dual u;  // the output scalar u = f(x, p) evaluated together with gradient below
+
+    VectorXd gx = gradient(f, wrt(x), at(x, p), u);  // evaluate the function value u and its gradient vector gx = du/dx
+    VectorXd gp = gradient(f, wrt(p), at(x, p), u);  // evaluate the function value u and its gradient vector gp = du/dp
+
+    cout << "u = " << u << endl;    // print the evaluated output u
+    cout << "gx = \n" << gx << endl;  // print the evaluated gradient vector gx = du/dx
+    cout << "gp = \n" << gp << endl;  // print the evaluated gradient vector gp = du/dp
+}

--- a/examples/forward/example-forward-gradient-derivatives-using-eigen.cpp
+++ b/examples/forward/example-forward-gradient-derivatives-using-eigen.cpp
@@ -22,10 +22,10 @@ int main()
     VectorXdual x(5);    // the input vector x with 5 variables
     x << 1, 2, 3, 4, 5;  // x = [1, 2, 3, 4, 5]
 
-    dual u = f(x);  // the output variable u
+    dual u;  // the output scalar u = f(x) evaluated together with gradient below
 
-    VectorXd dudx = gradient(f, x);  // evaluate the gradient vector du/dx
+    VectorXd g = gradient(f, wrt(x), at(x), u);  // evaluate the function value u and its gradient vector g = du/dx
 
-    cout << "u = " << u << endl;             // print the evaluated output u
-    cout << "grad(u) = \n" << dudx << endl;  // print the evaluated gradient vector du/dx
+    cout << "u = " << u << endl;    // print the evaluated output u
+    cout << "g = \n" << g << endl;  // print the evaluated gradient vector g = du/dx
 }

--- a/examples/forward/example-forward-higher-order-derivatives.cpp
+++ b/examples/forward/example-forward-higher-order-derivatives.cpp
@@ -21,15 +21,14 @@ int main()
     dual2nd y = 1.0;      // the input variable y
     dual2nd u = f(x, y);  // the output variable u
 
-    dual ux = derivative(f, wrt(x), x, y);  // evaluate the derivative du/dx
-    dual uy = derivative(f, wrt(y), x, y);  // evaluate the derivative du/dy
+    dual ux = derivative(f, wrt(x), at(x, y));  // evaluate the derivative du/dx
+    dual uy = derivative(f, wrt(y), at(x, y));  // evaluate the derivative du/dy
 
-    double uxx = derivative(f, wrt(x, x), x, y);  // evaluate the derivative d²u/dxdx
-    double uxy = derivative(f, wrt(x, y), x, y);  // evaluate the derivative d²u/dxdy
-    double uyx = derivative(f, wrt(y, x), x, y);  // evaluate the derivative d²u/dydx
-    double uyy = derivative(f, wrt(y, y), x, y);  // evaluate the derivative d²u/dydy
+    double uxx = derivative(f, wrt(x, x), at(x, y));  // evaluate the derivative d²u/dxdx
+    double uxy = derivative(f, wrt(x, y), at(x, y));  // evaluate the derivative d²u/dxdy
+    double uyx = derivative(f, wrt(y, x), at(x, y));  // evaluate the derivative d²u/dydx
+    double uyy = derivative(f, wrt(y, y), at(x, y));  // evaluate the derivative d²u/dydy
 
-    cout << "Allan" << endl;
     cout << "u   = " << u << endl;    // print the evaluated output u
     cout << "ux  = " << ux << endl;   // print the evaluated derivative du/dx
     cout << "uy  = " << uy << endl;   // print the evaluated derivative du/dy

--- a/examples/forward/example-forward-jacobian-derivatives-using-eigen-with-parameters.cpp
+++ b/examples/forward/example-forward-jacobian-derivatives-using-eigen-with-parameters.cpp
@@ -1,0 +1,36 @@
+// C++ includes
+#include <iostream>
+using namespace std;
+
+// Eigen includes
+#include <eigen3/Eigen/Core>
+using namespace Eigen;
+
+// autodiff include
+#include <autodiff/forward.hpp>
+#include <autodiff/forward/eigen.hpp>
+using namespace autodiff;
+
+// The vector function with parameters for which the Jacobian is needed
+VectorXdual f(const VectorXdual& x, const VectorXdual& p)
+{
+    return x * exp(p.sum());
+}
+
+int main()
+{
+    VectorXdual x(5);    // the input vector x with 5 variables
+    x << 1, 2, 3, 4, 5;  // x = [1, 2, 3, 4, 5]
+
+    VectorXdual p(3);    // the input parameter vector p with 3 variables
+    p << 1, 2, 3;        // p = [1, 2, 3]
+
+    VectorXdual F;  // the output vector F = f(x, p) evaluated together with Jacobian below
+
+    MatrixXd Jx = jacobian(f, wrt(x), at(x, p), F);  // evaluate the function and the Jacobian matrix dF/dx
+    MatrixXd Jp = jacobian(f, wrt(p), at(x, p), F);  // evaluate the function and the Jacobian matrix dF/dp
+
+    cout << "F = \n" << F << endl;    // print the evaluated output vector F
+    cout << "Jx = \n" << Jx << endl;  // print the evaluated Jacobian matrix dF/dx
+    cout << "Jp = \n" << Jp << endl;  // print the evaluated Jacobian matrix dF/dp
+}

--- a/examples/forward/example-forward-jacobian-derivatives-using-eigen.cpp
+++ b/examples/forward/example-forward-jacobian-derivatives-using-eigen.cpp
@@ -22,10 +22,10 @@ int main()
     VectorXdual x(5);    // the input vector x with 5 variables
     x << 1, 2, 3, 4, 5;  // x = [1, 2, 3, 4, 5]
 
-    VectorXdual u = f(x);  // the output vector u
+    VectorXdual F;  // the output vector F = f(x) evaluated together with Jacobian matrix below
 
-    MatrixXd dudx = jacobian(f, u, x);  // evaluate the Jacobian matrix du/dx
+    MatrixXd J = jacobian(f, wrt(x), at(x), F);  // evaluate the output vector F and the Jacobian matrix dF/dx
 
-    cout << "u = \n" << u << endl;         // print the evaluated output vector u
-    cout << "du/dx = \n" << dudx << endl;  // print the evaluated Jacobian matrix du/dx
+    cout << "F = \n" << F << endl;  // print the evaluated output vector F
+    cout << "J = \n" << J << endl;  // print the evaluated Jacobian matrix dF/dx
 }

--- a/examples/forward/example-forward-multi-variable-function-with-parameters.cpp
+++ b/examples/forward/example-forward-multi-variable-function-with-parameters.cpp
@@ -27,13 +27,14 @@ int main()
     params.b = 2.0;  // the parameter b of type dual, not double!
     params.c = 3.0;  // the parameter c of type dual, not double!
 
-    dual x = 0.5;           // the input variable x
+    dual x = 0.5;  // the input variable x
+
     dual u = f(x, params);  // the output variable u
 
-    double dudx = derivative(f, wrt(x), x, params);        // evaluate the derivative du/dx
-    double duda = derivative(f, wrt(params.a), x, params); // evaluate the derivative du/da
-    double dudb = derivative(f, wrt(params.b), x, params); // evaluate the derivative du/db
-    double dudc = derivative(f, wrt(params.c), x, params); // evaluate the derivative du/dc
+    double dudx = derivative(f, wrt(x), at(x, params));        // evaluate the derivative du/dx
+    double duda = derivative(f, wrt(params.a), at(x, params)); // evaluate the derivative du/da
+    double dudb = derivative(f, wrt(params.b), at(x, params)); // evaluate the derivative du/db
+    double dudc = derivative(f, wrt(params.c), at(x, params)); // evaluate the derivative du/dc
 
     cout << "u = " << u << endl;         // print the evaluated output u
     cout << "du/dx = " << dudx << endl;  // print the evaluated derivative du/dx

--- a/examples/forward/example-forward-multi-variable-function.cpp
+++ b/examples/forward/example-forward-multi-variable-function.cpp
@@ -14,14 +14,15 @@ dual f(dual x, dual y, dual z)
 
 int main()
 {
-    dual x = 1.0;         // the input variable x
-    dual y = 2.0;         // the input variable y
-    dual z = 3.0;         // the input variable z
-    dual u = f(x, y, z);  // the output variable u
+    dual x = 1.0;  // the input variable x
+    dual y = 2.0;  // the input variable y
+    dual z = 3.0;  // the input variable z
 
-    double dudx = derivative(f, wrt(x), x, y, z);  // evaluate the derivative du/dx
-    double dudy = derivative(f, wrt(y), x, y, z);  // evaluate the derivative du/dy
-    double dudz = derivative(f, wrt(z), x, y, z);  // evaluate the derivative du/dz
+    dual u = f(x, y, z);  // the output scalar u = f(x, y, z)
+
+    double dudx = derivative(f, wrt(x), at(x, y, z));  // evaluate du/dx
+    double dudy = derivative(f, wrt(y), at(x, y, z));  // evaluate du/dy
+    double dudz = derivative(f, wrt(z), at(x, y, z));  // evaluate du/dz
 
     cout << "u = " << u << endl;         // print the evaluated output u
     cout << "du/dx = " << dudx << endl;  // print the evaluated derivative du/dx

--- a/examples/forward/example-forward-single-variable-function.cpp
+++ b/examples/forward/example-forward-single-variable-function.cpp
@@ -17,7 +17,7 @@ int main()
     dual x = 2.0;   // the input variable x
     dual u = f(x);  // the output variable u
 
-    double dudx = derivative(f, wrt(x), x);  // evaluate the derivative du/dx
+    double dudx = derivative(f, wrt(x), at(x));  // evaluate the derivative du/dx
 
     cout << "u = " << u << endl;         // print the evaluated output u
     cout << "du/dx = " << dudx << endl;  // print the evaluated derivative du/dx

--- a/test/forward.test.cpp
+++ b/test/forward.test.cpp
@@ -81,27 +81,27 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         // Testing positive operator on a dual
         f = [](dual x) -> dual { return +x; };
         REQUIRE( f(x) == x );
-        REQUIRE( derivative(f, wrt(x), x) == 1.0 );
+        REQUIRE( derivative(f, wrt(x), at(x)) == 1.0 );
 
         // Testing positive operator on an expression
         f = [](dual x) -> dual { return +(x * x); };
         REQUIRE( f(x) == x * x );
-        REQUIRE( derivative(f, wrt(x), x) == 2.0 * x );
+        REQUIRE( derivative(f, wrt(x), at(x)) == 2.0 * x );
 
         // Testing negative operator on a dual
         f = [](dual x) -> dual { return -x; };
         REQUIRE( f(x) == -x );
-        REQUIRE( derivative(f, wrt(x), x) == -1.0 );
+        REQUIRE( derivative(f, wrt(x), at(x)) == -1.0 );
 
         // Testing negative operator on a negative expression
         f = [](dual x) -> dual { return -(-x); };
         REQUIRE( f(x) == x );
-        REQUIRE( derivative(f, wrt(x), x) == 1.0 );
+        REQUIRE( derivative(f, wrt(x), at(x)) == 1.0 );
 
         // Testing negative operator on a scaling expression expression
         f = [](dual x) -> dual { return -(2.0 * x); };
         REQUIRE( f(x) == -2.0 * x );
-        REQUIRE( derivative(f, wrt(x), x) == -2.0 );
+        REQUIRE( derivative(f, wrt(x), at(x)) == -2.0 );
     }
     SECTION("testing unary inverse operator")
     {
@@ -110,22 +110,22 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         // Testing inverse operator on a dual
         f = [](dual x) -> dual { return 1.0 / x; };
         REQUIRE( f(x) == 1/x );
-        REQUIRE( derivative(f, wrt(x), x) == -1.0 / (x * x) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == -1.0 / (x * x) );
 
         // Testing inverse operator on a trivial expression
         f = [](dual x) -> dual { return x / x; };
         REQUIRE( f(x) == 1.0 );
-        REQUIRE( derivative(f, wrt(x), x) == 0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x)) == 0.0 );
 
         // Testing inverse operator on an inverse expression
         f = [](dual x) -> dual { return 1.0 / (1.0 / x); };
         REQUIRE( f(x) == x );
-        REQUIRE( derivative(f, wrt(x), x) == 1.0 );
+        REQUIRE( derivative(f, wrt(x), at(x)) == 1.0 );
 
         // Testing inverse operator on a scaling expression
         f = [](dual x) -> dual { return 1.0 / (2.0 * x); };
         REQUIRE( f(x) == 0.5 / x );
-        REQUIRE( derivative(f, wrt(x), x) == -0.5 / (x * x) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == -0.5 / (x * x) );
     }
 
     SECTION("testing binary addition operator")
@@ -135,38 +135,38 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         // Testing addition operator on a `number + dual` expression
         f = [](dual x, dual y) -> dual { return 1 + x; };
         REQUIRE( f(x, y) == 1 + val(x) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == 0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 0.0 );
 
         // Testing addition operator on a `dual + number` expression
         f = [](dual x, dual y) -> dual { return x + 1; };
         REQUIRE( f(x, y) == val(x) + 1 );
-        REQUIRE( derivative(f, wrt(x), x, y) == 1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == 0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 0.0 );
 
         // Testing addition operator on a `dual + dual` expression
         f = [](dual x, dual y) -> dual { return (-x) + (-y); };
         REQUIRE( f(x, y) == -(val(x) + val(y)) );
-        REQUIRE( derivative(f, wrt(x), x, y) == -1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == -1.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == -1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == -1.0 );
 
         // Testing addition operator on a `(-dual) + (-dual)` expression
         f = [](dual x, dual y) -> dual { return (-x) + (-y); };
         REQUIRE( f(x, y) == -(val(x) + val(y)) );
-        REQUIRE( derivative(f, wrt(x), x, y) == -1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == -1.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == -1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == -1.0 );
 
         // Testing addition operator on a `dual * dual + dual * dual` expression
         f = [](dual x, dual y) -> dual { return x * y + x * y; };
         REQUIRE( f(x, y) == 2.0 * (val(x) * val(y)) );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx( 2.0 * y ) );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx( 2.0 * x ) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx( 2.0 * y ) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx( 2.0 * x ) );
 
         // Testing addition operator on a `1/dual * 1/dual` expression
         f = [](dual x, dual y) -> dual { return 1.0 / x + 1.0 / y; };
         REQUIRE( f(x, y) == approx( 1.0 / val(x) + 1.0 / val(y)) );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx( -1.0 / (x * x) ) );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx( -1.0 / (y * y) ) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx( -1.0 / (x * x) ) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx( -1.0 / (y * y) ) );
     }
 
     SECTION("testing binary subtraction operator")
@@ -176,32 +176,32 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         // Testing subtraction operator on a `number - dual` expression
         f = [](dual x, dual y) -> dual { return 1 - x; };
         REQUIRE( f(x, y) == 1 - val(x) );
-        REQUIRE( derivative(f, wrt(x), x, y) == -1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) ==  0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == -1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) ==  0.0 );
 
         // Testing subtraction operator on a `dual - number` expression
         f = [](dual x, dual y) -> dual { return x - 1; };
         REQUIRE( f(x, y) == val(x) - 1 );
-        REQUIRE( derivative(f, wrt(x), x, y) == 1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == 0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 0.0 );
 
         // Testing subtraction operator on a `(-dual) - (-dual)` expression
         f = [](dual x, dual y) -> dual { return (-x) - (-y); };
         REQUIRE( f(x, y) == -(val(x) - val(y)) );
-        REQUIRE( derivative(f, wrt(x), x, y) == -1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) ==  1.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == -1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) ==  1.0 );
 
         // Testing subtraction operator on a `dual * dual - dual * dual` expression
         f = [](dual x, dual y) -> dual { return x * y - x * y; };
         REQUIRE( f(x, y) == 0.0 );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx( 0.0 ) );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx( 0.0 ) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx( 0.0 ) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx( 0.0 ) );
 
         // Testing subtraction operator on a `1/dual * 1/dual` expression
         f = [](dual x, dual y) -> dual { return 1.0 / x - 1.0 / y; };
         REQUIRE( f(x, y) == approx( 1.0 / val(x) - 1.0 / val(y)) );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx( -1.0 / (x * x) ) );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(  1.0 / (y * y) ) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx( -1.0 / (x * x) ) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(  1.0 / (y * y) ) );
     }
 
     SECTION("testing binary multiplication operator")
@@ -211,56 +211,56 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         // Testing multiplication operator on a `number * dual` expression
         f = [](dual x, dual y) -> dual { return 2.0 * x; };
         REQUIRE( f(x, y) == 2.0 * val(x) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 2.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == 0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 2.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 0.0 );
 
         // Testing multiplication operator on a `dual * number` expression
         f = [](dual x, dual y) -> dual { return x * 2; };
         REQUIRE( f(x, y) == 2.0 * val(x) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 2.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == 0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 2.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 0.0 );
 
         // Testing multiplication operator on a `dual * dual` expression
         f = [](dual x, dual y) -> dual { return x * y; };
         REQUIRE( f(x, y) == val(x) * val(y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == y );
-        REQUIRE( derivative(f, wrt(y), x, y) == x );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == y );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == x );
 
         // Testing multiplication operator on a `number * (number * dual)` expression
         f = [](dual x, dual y) -> dual { return 5 * (2.0 * x); };
         REQUIRE( f(x, y) == 10 * val(x) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 10.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) ==  0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 10.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) ==  0.0 );
 
         // Testing multiplication operator on a `(dual * number) * number` expression
         f = [](dual x, dual y) -> dual { return (x * 2) * 5; };
         REQUIRE( f(x, y) == 10 * val(x) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 10.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) ==  0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 10.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) ==  0.0 );
 
         // Testing multiplication operator on a `number * (-dual)` expression
         f = [](dual x, dual y) -> dual { return 2.0 * (-x); };
         REQUIRE( f(x, y) == -2.0 * val(x) );
-        REQUIRE( derivative(f, wrt(x), x, y) == -2.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) ==  0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == -2.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) ==  0.0 );
 
         // Testing multiplication operator on a `(-dual) * number` expression
         f = [](dual x, dual y) -> dual { return (-x) * 2; };
         REQUIRE( f(x, y) == -2.0 * val(x) );
-        REQUIRE( derivative(f, wrt(x), x, y) == -2.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) ==  0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == -2.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) ==  0.0 );
 
         // Testing multiplication operator on a `(-dual) * (-dual)` expression
         f = [](dual x, dual y) -> dual { return (-x) * (-y); };
         REQUIRE( f(x, y) == val(x) * val(y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == y );
-        REQUIRE( derivative(f, wrt(y), x, y) == x );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == y );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == x );
 
         // Testing multiplication operator on a `(1/dual) * (1/dual)` expression
         f = [](dual x, dual y) -> dual { return (1 / x) * (1 / y); };
         REQUIRE( f(x, y) == 1 / (val(x) * val(y)) );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx(-1/(x * x * y)) );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(-1/(x * y * y)) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx(-1/(x * x * y)) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(-1/(x * y * y)) );
     }
 
     SECTION("testing binary division operator")
@@ -270,32 +270,32 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         // Testing division operator on a `number / dual` expression
         f = [](dual x, dual y) -> dual { return 1 / x; };
         REQUIRE( f(x, y) == 1 / val(x) );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx(-1.0 / (x * x)) );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(0.0) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx(-1.0 / (x * x)) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(0.0) );
 
         // Testing division operator on a `dual / number` expression
         f = [](dual x, dual y) -> dual { return x / 2; };
         REQUIRE( f(x, y) == val(x) / 2 );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx(0.5) );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(0.0) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx(0.5) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(0.0) );
 
         // Testing division operator on a `dual / dual` expression
         f = [](dual x, dual y) -> dual { return x / y; };
         REQUIRE( f(x, y) == val(x) / val(y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx(1 / y) );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(-x / (y * y)) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx(1 / y) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(-x / (y * y)) );
 
         // Testing division operator on a `1 / (number * dual)` expression
         f = [](dual x, dual y) -> dual { return 1 / (2.0 * x); };
         REQUIRE( f(x, y) == approx(0.5 / x) );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx(-0.5 / (x * x)) );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(0.0) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx(-0.5 / (x * x)) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(0.0) );
 
         // Testing division operator on a `1 / (1 / dual)` expression
         f = [](dual x, dual y) -> dual { return 1 / (1 / x); };
         REQUIRE( f(x, y) == val(x) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == 0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 0.0 );
     }
 
     SECTION("testing operator+=")
@@ -304,43 +304,43 @@ TEST_CASE("autodiff::dual tests", "[dual]")
 
         f = [](dual x, dual y) -> dual { return x += 1; };
         REQUIRE( f(x, y) == approx(x + 1) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == 0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 0.0 );
 
         f = [](dual x, dual y) -> dual { return x += y; };
         REQUIRE( f(x, y) == approx(x + y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == 1.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 1.0 );
 
         f = [](dual x, dual y) -> dual { return x += -y; };
         REQUIRE( f(x, y) == approx(x - y) );
-        REQUIRE( derivative(f, wrt(x), x, y) ==  1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == -1.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) ==  1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == -1.0 );
 
         f = [](dual x, dual y) -> dual { return x += -(x - y); };
         REQUIRE( f(x, y) == approx(y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 0.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == 1.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 0.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 1.0 );
 
         f = [](dual x, dual y) -> dual { return x += 1.0 / y; };
         REQUIRE( f(x, y) == approx(x + 1.0 / y) );
-        REQUIRE( derivative(f, wrt(x), x, y) ==  1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(-1.0 / (y * y)) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) ==  1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(-1.0 / (y * y)) );
 
         f = [](dual x, dual y) -> dual { return x += 2.0 * y; };
         REQUIRE( f(x, y) == approx(x + 2.0 * y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == 2.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 2.0 );
 
         f = [](dual x, dual y) -> dual { return x += x * y; };
         REQUIRE( f(x, y) == approx(x + x * y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 1.0 + y );
-        REQUIRE( derivative(f, wrt(y), x, y) == x );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 1.0 + y );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == x );
 
         f = [](dual x, dual y) -> dual { return x += x + y; };
         REQUIRE( f(x, y) == approx(x + x + y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 2.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == 1.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 2.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 1.0 );
     }
 
     SECTION("testing operator-=")
@@ -349,43 +349,43 @@ TEST_CASE("autodiff::dual tests", "[dual]")
 
         f = [](dual x, dual y) -> dual { return x -= 1; };
         REQUIRE( f(x, y) == approx(x - 1) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == 0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 0.0 );
 
         f = [](dual x, dual y) -> dual { return x -= y; };
         REQUIRE( f(x, y) == approx(x - y) );
-        REQUIRE( derivative(f, wrt(x), x, y) ==  1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == -1.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) ==  1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == -1.0 );
 
         f = [](dual x, dual y) -> dual { return x -= -y; };
         REQUIRE( f(x, y) == approx(x + y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == 1.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 1.0 );
 
         f = [](dual x, dual y) -> dual { return x -= -(x - y); };
         REQUIRE( f(x, y) == approx(2.0 * x - y) );
-        REQUIRE( derivative(f, wrt(x), x, y) ==  2.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == -1.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) ==  2.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == -1.0 );
 
         f = [](dual x, dual y) -> dual { return x -= 1.0 / y; };
         REQUIRE( f(x, y) == approx(x - 1.0 / y) );
-        REQUIRE( derivative(f, wrt(x), x, y) ==  1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(1.0 / (y * y)) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) ==  1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(1.0 / (y * y)) );
 
         f = [](dual x, dual y) -> dual { return x -= 2.0 * y; };
         REQUIRE( f(x, y) == approx(x - 2.0 * y) );
-        REQUIRE( derivative(f, wrt(x), x, y) ==  1.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == -2.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) ==  1.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == -2.0 );
 
         f = [](dual x, dual y) -> dual { return x -= x * y; };
         REQUIRE( f(x, y) == approx(x - x * y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 1.0 - y );
-        REQUIRE( derivative(f, wrt(y), x, y) == -x );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 1.0 - y );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == -x );
 
         f = [](dual x, dual y) -> dual { return x -= x - y; };
         REQUIRE( f(x, y) == approx(y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 0.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == 1.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 0.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 1.0 );
     }
 
     SECTION("testing operator*=")
@@ -394,43 +394,43 @@ TEST_CASE("autodiff::dual tests", "[dual]")
 
         f = [](dual x, dual y) -> dual { return x *= 2; };
         REQUIRE( f(x, y) == approx(2.0 * x) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 2.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == 0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 2.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 0.0 );
 
         f = [](dual x, dual y) -> dual { return x *= y; };
         REQUIRE( f(x, y) == approx(x * y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == y );
-        REQUIRE( derivative(f, wrt(y), x, y) == x );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == y );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == x );
 
         f = [](dual x, dual y) -> dual { return x *= -x; };
         REQUIRE( f(x, y) == approx(-x * x) );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx(-2.0 * x) );
-        REQUIRE( derivative(f, wrt(y), x, y) == 0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx(-2.0 * x) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 0.0 );
 
         f = [](dual x, dual y) -> dual { return x *= (2.0 / y); };
         REQUIRE( f(x, y) == approx(2.0 * x / y) );
-        REQUIRE( derivative(f, wrt(x), x, y) ==  2.0 / y );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(-2.0 * x / (y * y)) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) ==  2.0 / y );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(-2.0 * x / (y * y)) );
 
         f = [](dual x, dual y) -> dual { return x *= (2.0 * x); };
         REQUIRE( f(x, y) == approx(2.0 * x * x) );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx(4.0 * x) );
-        REQUIRE( derivative(f, wrt(y), x, y) == 0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx(4.0 * x) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 0.0 );
 
         f = [](dual x, dual y) -> dual { return x *= (2.0 * y); };
         REQUIRE( f(x, y) == approx(2.0 * x * y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 2.0 * y );
-        REQUIRE( derivative(f, wrt(y), x, y) == 2.0 * x );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 2.0 * y );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 2.0 * x );
 
         f = [](dual x, dual y) -> dual { return x *= x + y; };
         REQUIRE( f(x, y) == approx(x * (x + y)) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 2.0 * x + y );
-        REQUIRE( derivative(f, wrt(y), x, y) == x );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 2.0 * x + y );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == x );
 
         f = [](dual x, dual y) -> dual { return x *= x * y; };
         REQUIRE( f(x, y) == approx(x * (x * y)) );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx(2.0 * x * y) );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(x * x) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx(2.0 * x * y) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(x * x) );
     }
 
     SECTION("testing operator/=")
@@ -439,38 +439,38 @@ TEST_CASE("autodiff::dual tests", "[dual]")
 
         f = [](dual x, dual y) -> dual { return x /= 2; };
         REQUIRE( f(x, y) == approx(0.5 * x) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 0.5 );
-        REQUIRE( derivative(f, wrt(y), x, y) == 0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 0.5 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 0.0 );
 
         f = [](dual x, dual y) -> dual { return x /= y; };
         REQUIRE( f(x, y) == approx(x / y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx(1.0 / y) );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(-x / (y * y)) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx(1.0 / y) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(-x / (y * y)) );
 
         f = [](dual x, dual y) -> dual { return x /= -x; };
         REQUIRE( f(x, y) == approx(-1.0) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 0.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == 0.0 );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 0.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 0.0 );
 
         f = [](dual x, dual y) -> dual { return x /= (2.0 / y); };
         REQUIRE( f(x, y) == approx(0.5 * x * y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 0.5 * y );
-        REQUIRE( derivative(f, wrt(y), x, y) == 0.5 * x );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 0.5 * y );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == 0.5 * x );
 
         f = [](dual x, dual y) -> dual { return x /= (2.0 * y); };
         REQUIRE( f(x, y) == approx(0.5 * x / y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx( 0.5 / y) );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(-0.5 * x / (y * y)) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx( 0.5 / y) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(-0.5 * x / (y * y)) );
 
         f = [](dual x, dual y) -> dual { return x /= x + y; };
         REQUIRE( f(x, y) == approx(x / (x + y)) );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx(1.0 / (x + y) - x / (x + y) / (x + y)) );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(-x / (x + y) / (x + y)) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx(1.0 / (x + y) - x / (x + y) / (x + y)) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(-x / (x + y) / (x + y)) );
 
         f = [](dual x, dual y) -> dual { return x /= x * y; };
         REQUIRE( f(x, y) == approx(1.0 / y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == 0.0 );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(-1.0 / (y * y)) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == 0.0 );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(-1.0 / (y * y)) );
     }
 
     SECTION("testing combination of operations")
@@ -480,14 +480,14 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         // Testing multiplication with addition
         f = [](dual x, dual y) -> dual { return 2.0 * x + y; };
         REQUIRE( f(x, y) == 2.0 * val(x) + val(y) );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx(2.0) );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(1.0) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx(2.0) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(1.0) );
 
         // Testing a complex expression that is actually equivalent to one
         f = [](dual x, dual y) -> dual { return (2.0 * x * x - x * y + x / y + x / (2.0 * y)) / (x * (2.0 * x - y + 1 / y + 1 / (2.0 * y))); };
         REQUIRE( f(x, y) == approx(1.0) );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx(0.0) );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(0.0) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx(0.0) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(0.0) );
     }
 
     SECTION("testing mathematical functions")
@@ -499,76 +499,76 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         // Testing sin function
         f = [](dual x) -> dual { return sin(x); };
         REQUIRE( f(x) == std::sin(val(x)) );
-        REQUIRE( derivative(f, wrt(x), x) == approx(cos(x)) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(cos(x)) );
 
         // Testing cos function
         f = [](dual x) -> dual { return cos(x); };
         REQUIRE( f(x) == std::cos(val(x)) );
-        REQUIRE( derivative(f, wrt(x), x) == approx(-sin(x)) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(-sin(x)) );
 
         // Testing tan function
         f = [](dual x) -> dual { return tan(x); };
         REQUIRE( f(x) == std::tan(val(x)) );
-        REQUIRE( derivative(f, wrt(x), x) == approx(1 / (cos(x) * cos(x))) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(1 / (cos(x) * cos(x))) );
 
         // Testing asin function
         f = [](dual x) -> dual { return asin(x); };
         REQUIRE( f(x) == std::asin(val(x)) );
-        REQUIRE( derivative(f, wrt(x), x) == approx(1 / sqrt(1 - x * x)) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(1 / sqrt(1 - x * x)) );
 
         // Testing acos function
         f = [](dual x) -> dual { return acos(x); };
         REQUIRE( f(x) == std::acos(val(x)) );
-        REQUIRE( derivative(f, wrt(x), x) == approx(-1 / sqrt(1 - x * x)) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(-1 / sqrt(1 - x * x)) );
 
         // Testing atan function
         f = [](dual x) -> dual { return atan(x); };
         REQUIRE( f(x) == std::atan(val(x)) );
-        REQUIRE( derivative(f, wrt(x), x) == approx(1 / (1 + x * x)) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(1 / (1 + x * x)) );
 
         // Testing exp function
         f = [](dual x) -> dual { return exp(x); };
         REQUIRE( f(x) == std::exp(val(x)) );
-        REQUIRE( derivative(f, wrt(x), x) == approx(exp(x)) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(exp(x)) );
 
         // Testing log function
         f = [](dual x) -> dual { return log(x); };
         REQUIRE( f(x) == std::log(val(x)) );
-        REQUIRE( derivative(f, wrt(x), x) == approx(1 / x) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(1 / x) );
 
         // Testing log function
         f = [](dual x) -> dual { return log10(x); };
         REQUIRE( f(x) == std::log10(val(x)) );
-        REQUIRE( derivative(f, wrt(x), x) == approx(1 / (log(10) * x)) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(1 / (log(10) * x)) );
 
         // Testing sqrt function
         f = [](dual x) -> dual { return sqrt(x); };
         REQUIRE( f(x) == std::sqrt(val(x)) );
-        REQUIRE( derivative(f, wrt(x), x) == approx(0.5 / sqrt(x)) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(0.5 / sqrt(x)) );
 
         // Testing pow function (with number exponent)
         f = [](dual x) -> dual { return pow(x, 2.0); };
         REQUIRE( f(x) == std::pow(val(x), 2.0) );
-        REQUIRE( derivative(f, wrt(x), x) == approx(2.0 * x) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(2.0 * x) );
 
         // Testing pow function (with dual exponent)
         f = [](dual x) -> dual { return pow(x, x); };
         REQUIRE( f(x) == std::pow(val(x), val(x)) );
-        REQUIRE( derivative(f, wrt(x), x) == approx((log(x) + 1) * pow(x, x)) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx((log(x) + 1) * pow(x, x)) );
 
         // Testing pow function (with expression exponent)
         f = [](dual x) -> dual { return pow(x, 2.0 * x); };
         REQUIRE( f(x) == std::pow(val(x), 2.0 * val(x)) );
-        REQUIRE( derivative(f, wrt(x), x) == approx(2.0 * (log(x) + 1) * pow(x, 2.0 * x)) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(2.0 * (log(x) + 1) * pow(x, 2.0 * x)) );
 
         // Testing abs function (when x > 0 and when x < 0)
         f = [](dual x) -> dual { return abs(x); };
         x = 1.0;
         REQUIRE( f(x) == std::abs(val(x)) );
-        REQUIRE( derivative(f, wrt(x), x) == approx(1.0) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(1.0) );
         x = -1.0;
         REQUIRE( f(x) == std::abs(val(x)) );
-        REQUIRE( derivative(f, wrt(x), x) == approx(-1.0) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(-1.0) );
     }
 
     SECTION("testing complex expressions")
@@ -581,14 +581,14 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         // Testing complex function involving sin, cos, and tan
         f = [](dual x, dual y) -> dual { return sin(x + y) * cos(x / y) + tan(2.0 * x * y) - sin(4*(x + y)*2/8) * cos(x*x / (y*y) * y/x) - tan((x + y) * (x + y) - x*x - y*y); };
         REQUIRE( val(f(x, y)) == approx(0.0) );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx(0.0) );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(0.0) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx(0.0) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(0.0) );
 
         // Testing complex function involving log, exp, pow, and sqrt
         f = [](dual x, dual y) -> dual { return log(x + y) * exp(x / y) + sqrt(2.0 * x * y) - 1 / pow(x, x + y) - exp(x*x / (y*y) * y/x) * log(4*(x + y)*2/8) - 4 * sqrt((x + y) * (x + y) - x*x - y*y) * 0.5 * 0.5 + 2 / pow(2.0 * x - x, y + x) * 0.5; };
         REQUIRE( val(f(x, y)) == approx(0.0) );
-        REQUIRE( derivative(f, wrt(x), x, y) == approx(0.0) );
-        REQUIRE( derivative(f, wrt(y), x, y) == approx(0.0) );
+        REQUIRE( derivative(f, wrt(x), at(x, y)) == approx(0.0) );
+        REQUIRE( derivative(f, wrt(y), at(x, y)) == approx(0.0) );
     }
 
 
@@ -605,11 +605,11 @@ TEST_CASE("autodiff::dual tests", "[dual]")
             return x*x + x*y + y*y;
         };
 
-        REQUIRE( val(derivative(f, wrt(x), x, y)) == Approx(17.0) );
-        REQUIRE( derivative(f, wrt(x, x), x, y) == Approx(2.0) );
-        REQUIRE( derivative(f, wrt(x, y), x, y) == Approx(1.0) );
-        REQUIRE( derivative(f, wrt(y, x), x, y) == Approx(1.0) );
-        REQUIRE( derivative(f, wrt(y, y), x, y) == Approx(2.0) );
+        REQUIRE( val(derivative(f, wrt(x), at(x, y))) == Approx(17.0) );
+        REQUIRE( derivative(f, wrt(x, x), at(x, y)) == Approx(2.0) );
+        REQUIRE( derivative(f, wrt(x, y), at(x, y)) == Approx(1.0) );
+        REQUIRE( derivative(f, wrt(y, x), at(x, y)) == Approx(1.0) );
+        REQUIRE( derivative(f, wrt(y, y), at(x, y)) == Approx(2.0) );
     }
 
     SECTION("testing higher order derivatives")
@@ -625,11 +625,11 @@ TEST_CASE("autodiff::dual tests", "[dual]")
             return (x + y)*(x + y)*(x + y);
         };
 
-        REQUIRE( derivative(f, wrt(x, x, x), x, y) == Approx(6.0) );
-        REQUIRE( derivative(f, wrt(x, x, x), x, y) == Approx(6.0) );
-        REQUIRE( derivative(f, wrt(x, x, y), x, y) == Approx(6.0) );
-        REQUIRE( derivative(f, wrt(x, y, y), x, y) == Approx(6.0) );
-        REQUIRE( derivative(f, wrt(y, y, y), x, y) == Approx(6.0) );
+        REQUIRE( derivative(f, wrt(x, x, x), at(x, y)) == Approx(6.0) );
+        REQUIRE( derivative(f, wrt(x, x, x), at(x, y)) == Approx(6.0) );
+        REQUIRE( derivative(f, wrt(x, x, y), at(x, y)) == Approx(6.0) );
+        REQUIRE( derivative(f, wrt(x, y, y), at(x, y)) == Approx(6.0) );
+        REQUIRE( derivative(f, wrt(y, y, y), at(x, y)) == Approx(6.0) );
     }
 
     SECTION("testing gradient derivatives")
@@ -643,11 +643,28 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         VectorXdual x(3);
         x << 1.0, 2.0, 3.0;
 
-        VectorXd g = gradient(f, x);
+        VectorXd g = gradient(f, wrt(x), at(x));
 
         REQUIRE( g[0] == approx(x[0]) );
         REQUIRE( g[1] == approx(x[1]) );
         REQUIRE( g[2] == approx(x[2]) );
+    }
+
+    SECTION("testing gradient derivatives of only the last two variables")
+    {
+        // Testing complex function involving sin and cos
+        auto f = [](const VectorXdual& x) -> dual
+        {
+            return 0.5 * ( x.array() * x.array() ).sum();
+        };
+
+        VectorXdual x(3);
+        x << 1.0, 2.0, 3.0;
+
+        VectorXd g = gradient(f, wrt(x.tail(2)), at(x));
+
+        REQUIRE( g[0] == approx(x[1]) );
+        REQUIRE( g[1] == approx(x[2]) );
     }
 
     SECTION("testing jacobian derivatives")
@@ -661,12 +678,32 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         VectorXdual x(3);
         x << 0.5, 0.2, 0.3;
 
-        VectorXdual u = f(x);
+        VectorXdual F;
 
-        MatrixXd J = jacobian(f, u, x);
+        const MatrixXd J = jacobian(f, wrt(x), at(x), F);
 
         for(auto i = 0; i < 3; ++i)
             for(auto j = 0; j < 3; ++j)
-                REQUIRE( J(i, j) == approx(-u[i] + ((i == j) ? 1.0 : 0.0)) );
+                REQUIRE( J(i, j) == approx(-F[i] + ((i == j) ? 1.0 : 0.0)) );
+    }
+
+    SECTION("testing jacobian derivatives of only the last two variables")
+    {
+        // Testing complex function involving sin and cos
+        auto f = [](const VectorXdual& x) -> VectorXdual
+        {
+            return x / x.array().sum();
+        };
+
+        VectorXdual x(3);
+        x << 0.5, 0.2, 0.3;
+
+        VectorXdual F;
+
+        const MatrixXd J = jacobian(f, wrt(x.tail(2)), at(x), F);
+
+        for(auto i = 0; i < 3; ++i)
+            for(auto j = 0; j < 2; ++j)
+                REQUIRE( J(i, j) == approx(-F[i] + ((i == j + 1) ? 1.0 : 0.0)) );
     }
 }


### PR DESCRIPTION
This PR introduces **BREAKING CHANGES**!

From now on, methods `derivative`, `gradient`, and `jacobian` require the
use of auxiliary functions `wrt` and the newly introduced one `at`.

Examples:

~~~c++
// f = f(x)
double dudx = derivative(f, wrt(x), at(x));
~~~

~~~c++
// f = f(x, y, z)
double dudx = derivative(f, wrt(x), at(x, y, z));
double dudy = derivative(f, wrt(y), at(x, y, z));
double dudz = derivative(f, wrt(z), at(x, y, z));
~~~

~~~c++
// f = f(x), scalar function, where x is an Eigen vector
VectorXd g = gradient(f, wrt(x), at(x));

// Compuring gradient with respect to only some variables
VectorXd gpartial = gradient(f, wrt(x.tail(5)), at(x));
~~~

~~~c++
// F = F(x), vector function, where x is an Eigen vector
MatrixXd J = jacobian(f, wrt(x), at(x));

// F = F(x, p), vector function with params, where x and p are Eigen vectors
MatrixXd Jx = jacobian(f, wrt(x), at(x, p));
MatrixXd Jp = jacobian(f, wrt(p), at(x, p));

// Compuring Jacobian with respect to only some variables
MatrixXd Jpartial = jacobian(f, wrt(x.tail(5)), at(x));
~~~

This release also permits one to retrieve the evaluated value of function during
a call to the methods `derivative`, `gradient`, and `jacobian`:

~~~c++
// f = f(x)
dual u;
double dudx = derivative(f, wrt(x), at(x), u);
~~~

~~~c++
// f = f(x), scalar function, where x is an Eigen vector
dual u;
VectorXd g = gradient(f, wrt(x), at(x), u);
~~~

~~~c++
// F = F(x), vector function, where x is an Eigen vector
VectorXdual F;
MatrixXd J = jacobian(f, wrt(x), at(x), F);
~~~