### PR TITLE
Improve Eigen dependency resolution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,5 +23,5 @@ add_subdirectory(autodiff)
 add_subdirectory(examples)
 add_subdirectory(test)
 
-# Install the cmake config files that permit users to use find_package(Reaktoro)
+# Install the cmake config files that permit users to use find_package(autodiff)
 include(autodiffInstallCMakeConfigFiles)

--- a/autodiff/CMakeLists.txt
+++ b/autodiff/CMakeLists.txt
@@ -1,6 +1,11 @@
+# Find Eigen library
+find_package(Eigen3 3.3 REQUIRED NO_MODULE)
 
 # Create the autodiff interface library
 add_library(autodiff INTERFACE)
+
+# Link autodiff against Eigen
+target_link_libraries(autodiff INTERFACE Eigen3::Eigen)
 
 # Set autodiff compilation features to be propagated to client code.
 target_compile_features(autodiff INTERFACE cxx_std_17)

--- a/cmake/autodiffConfig.cmake.in
+++ b/cmake/autodiffConfig.cmake.in
@@ -1,6 +1,9 @@
 # Recommended cmake macro use to write a cmake config file.
 @PACKAGE_INIT@
 
+# Find dependencies
+find_package(Eigen3 3.3 REQUIRED NO_MODULE)
+
 # Include the cmake targets of the project if they have not been yet.
 if(NOT TARGET autodiff::autodiff)
     include("@PACKAGE_AUTODIFF_INSTALL_CONFIGDIR@/autodiffTargets.cmake")


### PR DESCRIPTION
This PR aims to improve dependency resolution for Eigen by propagating Eigen dependency in autodiff to other targets (executables/libraries). This is a result of the discussion in #43 .