### PR TITLE
[Proposal] Make gradient vector and Jacobian matrix computation more general

### DIFF
--- a/autodiff/forward/eigen.hpp
+++ b/autodiff/forward/eigen.hpp
@@ -112,14 +112,21 @@ auto gradient(const Function& f, Wrt&& wrt, Args&& args, Result& u) -> Eigen::Ve
     detail::for_each(wrt, [&n](auto&& arg){ n += arg.size(); });
 
     Eigen::VectorXd g(n);
-
-    for(std::size_t j = 0; j < n; ++j)
+    
+    detail::for_each(wrt, [f, &args, &u, &g, index_aligment = std::size_t(0)](auto&& arg) mutable
     {
-        std::get<0>(wrt)[j].grad = 1.0;
-        u = std::apply(f, args);
-        std::get<0>(wrt)[j].grad = 0.0;
-        g[j] = u.grad;
-    }
+        std::size_t size = arg.size();
+
+        for (std::size_t j = 0; j < size; ++j)
+        {
+            arg[j].grad = 1.0;
+            u = std::apply(f, args);
+            arg[j].grad = 0.0;
+            g[j + index_aligment] = u.grad;
+        }
+
+        index_aligment += size;
+    });
 
     return g;
 }

--- a/autodiff/forward/eigen.hpp
+++ b/autodiff/forward/eigen.hpp
@@ -103,6 +103,24 @@ void for_each(Tuple&& tuple, Callable&& callable)
         std::forward<Tuple>(tuple)
     );
 }
+
+template <typename T>
+struct is_eigen_dual_matrix : std::false_type { };
+
+template <typename _Scalar, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols>
+struct is_eigen_dual_matrix<Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>> : traits::isDual<plain<_Scalar>> { };
+
+template <typename T>
+inline constexpr bool is_eigen_dual_container_v = is_eigen_dual_matrix<plain<T>>::value;
+
+template <typename T, typename Enable = void>
+struct is_eigen_dual_vector : std::false_type { };
+
+template <typename T>
+struct is_eigen_dual_vector<T, std::enable_if_t<is_eigen_dual_container_v<T>>> : std::bool_constant<plain<T>::IsVectorAtCompileTime> { };
+
+template <typename T>
+inline constexpr bool is_eigen_dual_vector_v = is_eigen_dual_vector<T>::value;
 }
 /// Return the gradient vector of scalar function *f* with respect to some or all variables *x*.
 template<typename Function, typename Wrt, typename Args, typename Result>


### PR DESCRIPTION
This is proposal (not finaly completed yet) of more general computition of gradient vector and Jacobian matrix computation. 
Through this implementation we can compute gradient for function with next signature:
```cpp
dual f(const VectorXdual& x, dual a, dual b, dual c)
{
    ...
}
```
Now we are able to call gradient wrt (a, b, c, x)
```cpp
 VectorXd g2 = gradient(f, wrt(a, b, c, x), at(x, a, b, c), u);
```

P.S.
Btw, I know why tests fail, and how to resolve this