### PR TITLE
Fix expression tree figure linking in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ possible to compute the contribution of each branch on the derivatives of the
 output variable with respect to input variables.
 
 <img
-    src='img/expression-tree-diagram.svg'
+    src='art/expression-tree-diagram.svg'
     style='max-width:100%;'
     title='Expression tree diagram.'>
 


### PR DESCRIPTION
Hi, Allan.

I was curious about autodiff and found a very minor problem. PR's reason is provided below:

This PR performs a very minor fix. In the autodiff's README from master branch, the expression tree figure is not properly loaded. This PR just update the link, pointing to the correct place.