### PR TITLE
Add explicit double convert operator for var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(CCache)
 
 # Name and details of the project
-project(autodiff VERSION 0.5.7 LANGUAGES CXX)
+project(autodiff VERSION 0.5.9 LANGUAGES CXX)
 
 # Include the cmake variables with values for installation directories
 include(GNUInstallDirs)

--- a/autodiff/forward/forward.hpp
+++ b/autodiff/forward/forward.hpp
@@ -1287,14 +1287,14 @@ constexpr void assignPow(Dual<T, G>& self, U&& other)
 {
     // ASSIGN-POW A NUMBER: self = pow(self, number)
     if constexpr (isNumber<U>) {
-        const T aux = std::pow(self.val, other - 1);
+        const T aux = pow(self.val, other - 1);
         self.grad *= other * aux;
         self.val = aux * self.val;
     }
     // ASSIGN-POW A DUAL NUMBER: self = pow(self, dual)
     else if constexpr (isDual<U>) {
-        const T aux1 = std::pow(self.val, other.val);
-        const T aux2 = std::log(self.val);
+        const T aux1 = pow(self.val, other.val);
+        const T aux2 = log(self.val);
         self.grad *= other.val/self.val;
         self.grad += aux2 * other.grad;
         self.grad *= aux1;
@@ -1350,7 +1350,7 @@ constexpr void apply(Dual<T, G>& self, CosOp)
 template<typename T, typename G>
 constexpr void apply(Dual<T, G>& self, TanOp)
 {
-    const T aux = One<T> / std::cos(self.val);
+    const T aux = One<T> / cos(self.val);
     self.val = tan(self.val);
     self.grad *= aux * aux;
 }

--- a/autodiff/reverse/reverse.hpp
+++ b/autodiff/reverse/reverse.hpp
@@ -663,6 +663,9 @@ struct var
     /// Implicitly convert this var object variable into an expression pointer
     operator ExprPtr() const { return expr; }
 
+    /// Explicitly convert this var object variable into a double value
+    explicit operator double() const { return expr->val; }
+
 	// Arithmetic-assignment operators
     var& operator+=(const ExprPtr& other) { expr = expr + other; return *this; }
     var& operator-=(const ExprPtr& other) { expr = expr - other; return *this; }


### PR DESCRIPTION
This PR satisfies (partially) the requirement asked in issue #55 .

One can now, in addition to using method `val`, use `static_cast<double>` to convert a `var` object into `double`.