### PR TITLE
[autodiff/forward] Simplify higher order derivatives

### DIFF
--- a/autodiff/forward/forward.hpp
+++ b/autodiff/forward/forward.hpp
@@ -591,6 +591,21 @@ auto seed(Arg& dual, Args&... duals) -> void
     dual.grad = num;
 }
 
+template<typename T>
+constexpr auto repeat(T&& t, std::index_sequence<0>) 
+{
+    // Just stop recursion
+    return std::forward_as_tuple(std::forward<T>(t));
+}
+
+template<typename T, std::size_t I, std::size_t... N>
+constexpr auto repeat(T&& t, std::index_sequence<I, N...>) 
+{
+    // concat tuple with rest N
+    return std::tuple_cat(std::forward_as_tuple(std::forward<T>(t)),
+        repeat<T>(std::forward<T>(t), std::make_index_sequence<sizeof...(N)>{}));
+}
+
 } // namespace internal
 
 template<typename Arg>

--- a/autodiff/forward/forward.hpp
+++ b/autodiff/forward/forward.hpp
@@ -640,6 +640,12 @@ auto wrt(Args&&... args)
     return std::forward_as_tuple(std::forward<Args>(args)...);
 }
 
+template<std::size_t N, typename Wrt>
+auto wrt(Wrt&& arg) 
+{
+    return internal::repeat<Wrt>(std::forward<Wrt>(arg), std::make_index_sequence<N>{});
+}
+
 template<typename... Args>
 auto at(Args&&... args)
 {

--- a/examples/forward/example-forward-higher-order-derivatives.cpp
+++ b/examples/forward/example-forward-higher-order-derivatives.cpp
@@ -24,10 +24,10 @@ int main()
     dual ux = derivative(f, wrt(x), at(x, y));  // evaluate the derivative du/dx
     dual uy = derivative(f, wrt(y), at(x, y));  // evaluate the derivative du/dy
 
-    double uxx = derivative(f, wrt(x, x), at(x, y));  // evaluate the derivative d²u/dxdx
+    double uxx = derivative(f, wrt<2>(x), at(x, y));  // evaluate the derivative d²u/dxdx
     double uxy = derivative(f, wrt(x, y), at(x, y));  // evaluate the derivative d²u/dxdy
     double uyx = derivative(f, wrt(y, x), at(x, y));  // evaluate the derivative d²u/dydx
-    double uyy = derivative(f, wrt(y, y), at(x, y));  // evaluate the derivative d²u/dydy
+    double uyy = derivative(f, wrt<2>(y), at(x, y));  // evaluate the derivative d²u/dydy
 
     cout << "u   = " << u << endl;    // print the evaluated output u
     cout << "ux  = " << ux << endl;   // print the evaluated derivative du/dx

--- a/test/forward.test.cpp
+++ b/test/forward.test.cpp
@@ -632,10 +632,10 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         };
 
         REQUIRE( val(derivative(f, wrt(x), at(x, y))) == Approx(17.0) );
-        REQUIRE( derivative(f, wrt(x, x), at(x, y)) == Approx(2.0) );
+        REQUIRE( derivative(f, wrt<2>(x), at(x, y)) == Approx(2.0) );
         REQUIRE( derivative(f, wrt(x, y), at(x, y)) == Approx(1.0) );
         REQUIRE( derivative(f, wrt(y, x), at(x, y)) == Approx(1.0) );
-        REQUIRE( derivative(f, wrt(y, y), at(x, y)) == Approx(2.0) );
+        REQUIRE( derivative(f, wrt<2>(y), at(x, y)) == Approx(2.0) );
 
         // Testing complex function involving log
         x = 2.0;
@@ -649,7 +649,7 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         REQUIRE( val(f(x, y)) == Approx( 1 + val(x) + val(y) + val(x) * val(y) + val(y) / val(x) + log(val(x) / val(y)) ) );
         REQUIRE( val(derivative(f, wrt(x), at(x, y))) == Approx( 1 + val(y) - val(y) / (val(x) * val(x)) + 1.0/val(x) - log(val(y)) ) );
         REQUIRE( val(derivative(f, wrt(y), at(x, y))) == Approx( 1 + val(x) + 1.0 / val(x) - 1.0/val(y) ) );
-        REQUIRE( val(derivative(f, wrt(x, x), at(x, y))) == Approx( 2 * val(y) / (val(x) * val(x) * val(x)) + -1.0/(val(x) * val(x)) ) );
+        REQUIRE( val(derivative(f, wrt<2>(x), at(x, y))) == Approx( 2 * val(y) / (val(x) * val(x) * val(x)) + -1.0/(val(x) * val(x)) ) );
         REQUIRE( val(derivative(f, wrt(y, y), at(x, y))) == Approx( 1.0/(val(y)*val(y)) ) );
         REQUIRE( val(derivative(f, wrt(y, x), at(x, y))) == Approx( 1 - 1.0 / (val(x) * val(x)) ) );
         REQUIRE( val(derivative(f, wrt(x, y), at(x, y))) == Approx( 1 - 1.0 / (val(x) * val(x)) ) );
@@ -668,11 +668,11 @@ TEST_CASE("autodiff::dual tests", "[dual]")
             return (x + y)*(x + y)*(x + y);
         };
 
-        REQUIRE( derivative(f, wrt(x, x, x), at(x, y)) == Approx(6.0) );
+        REQUIRE( derivative(f, wrt<3>(x), at(x, y)) == Approx(6.0) );
         REQUIRE( derivative(f, wrt(x, x, x), at(x, y)) == Approx(6.0) );
         REQUIRE( derivative(f, wrt(x, x, y), at(x, y)) == Approx(6.0) );
         REQUIRE( derivative(f, wrt(x, y, y), at(x, y)) == Approx(6.0) );
-        REQUIRE( derivative(f, wrt(y, y, y), at(x, y)) == Approx(6.0) );
+        REQUIRE( derivative(f, wrt<3>(y), at(x, y)) == Approx(6.0) );
     }
 
     SECTION("testing gradient derivatives")


### PR DESCRIPTION
Add new wrt function overloading. As we discussed #57 users want to use simpler way of higher-order derivatives calculation. I remember that @allanleal thought about changing dual implementation, but I'm not sure that it is necessary and easy to implement. Also, we will get regressions using such an approach. 
```cpp
using dual4th = Dual<double, 4>;

dual4th x = 1.0;
dual4th y = derivative(sin, wrt(x), at(x));

cout << y[0] << endl; // value of the 0th order derivative of sin(x), which is its actual value
cout << y[1] << endl; // value of the 1st order derivative of sin(x)
cout << y[2] << endl; // value of the 2nd order derivative of sin(x)
cout << y[3] << endl; // value of the 3rd order derivative of sin(x)
cout << y[4] << endl; // value of the 4th order derivative of sin(x)
```

Here we calculate 4 derivatives and it's mean that we call sin 4 times, what if the user wants only one in some cases? 

Consolations: We can change the implementation of Dual to avoid recursion, but we should not add overhead to the user, and that's mean that we need wrt in that form which we have =) correct me if I'm wrong.

P.S. FYI @ibell