### PR TITLE
Fix nan and/or segfault when using nested template functions

### DIFF
--- a/autodiff/forward/forward.hpp
+++ b/autodiff/forward/forward.hpp
@@ -607,14 +607,14 @@ auto seed(Arg& dual, Args&... duals) -> void
 }
 
 template<typename T>
-constexpr auto repeat(T&& t, std::index_sequence<0>) 
+constexpr auto repeat(T&& t, std::index_sequence<0>)
 {
     // Just stop recursion
     return std::forward_as_tuple(std::forward<T>(t));
 }
 
 template<typename T, std::size_t I, std::size_t... N>
-constexpr auto repeat(T&& t, std::index_sequence<I, N...>) 
+constexpr auto repeat(T&& t, std::index_sequence<I, N...>)
 {
     // concat tuple with rest N
     return std::tuple_cat(std::forward_as_tuple(std::forward<T>(t)),
@@ -656,7 +656,7 @@ auto wrt(Args&&... args)
 }
 
 template<std::size_t N, typename Wrt>
-auto wrt(Wrt&& arg) 
+auto wrt(Wrt&& arg)
 {
     return internal::repeat<Wrt>(std::forward<Wrt>(arg), std::make_index_sequence<N>{});
 }

--- a/autodiff/forward/forward.hpp
+++ b/autodiff/forward/forward.hpp
@@ -711,7 +711,7 @@ constexpr auto negative(U&& expr)
     static_assert(isExpr<U> || isNumber<U>);
     if constexpr (isNegExpr<U>)
         return inner(expr);
-    else return NegExpr<U>{ std::forward<U>(expr) };
+    else return NegExpr<U>{ expr };
 }
 
 //-----------------------------------------------------------------------------
@@ -723,7 +723,7 @@ constexpr auto inverse(U&& expr)
     static_assert(isExpr<U>);
     if constexpr (isInvExpr<U>)
         return inner(expr);
-    else return InvExpr<U>{ std::forward<U>(expr) };
+    else return InvExpr<U>{ expr };
 }
 
 //-----------------------------------------------------------------------------
@@ -766,7 +766,7 @@ constexpr auto operator-(R&& expr)
     else if constexpr (isNumberDualMulExpr<R>)
         return (-left(expr)) * right(expr);
     // default expression
-    else return NegExpr<R>{ std::forward<R>(expr) };
+    else return NegExpr<R>{ expr };
 }
 
 //=====================================================================================================================
@@ -785,7 +785,7 @@ constexpr auto operator+(L&& l, R&& r)
     else if constexpr (isExpr<L> && isNumber<R>)
         return std::forward<R>(r) + std::forward<L>(l);
     // DEFAULT ADDITION EXPRESSION
-    else return AddExpr<L, R>{ std::forward<L>(l), std::forward<R>(r) };
+    else return AddExpr<L, R>{ l, r };
 }
 
 //=====================================================================================================================
@@ -814,9 +814,9 @@ constexpr auto operator*(L&& l, R&& r)
         return (l * left(r)) * right(r);
     // MULTIPLICATION EXPRESSION CASE: number * dual => NumberDualMulExpr
     else if constexpr (isNumber<L> && isDual<R>)
-        return NumberDualMulExpr<L, R>{ std::forward<L>(l), std::forward<R>(r) };
+        return NumberDualMulExpr<L, R>{ l, r };
     // DEFAULT MULTIPLICATION EXPRESSION: expr * expr => MulExpr
-    else return MulExpr<L, R>{ std::forward<L>(l), std::forward<R>(r) };
+    else return MulExpr<L, R>{ l, r };
 }
 
 //=====================================================================================================================
@@ -857,12 +857,12 @@ constexpr auto operator/(L&& l, R&& r)
 //
 //=====================================================================================================================
 
-template<typename R, enableif<isExpr<R>>...> constexpr auto sin(R&& r) -> SinExpr<R> { return { std::forward<R>(r) }; }
-template<typename R, enableif<isExpr<R>>...> constexpr auto cos(R&& r) -> CosExpr<R> { return { std::forward<R>(r) }; }
-template<typename R, enableif<isExpr<R>>...> constexpr auto tan(R&& r) -> TanExpr<R> { return { std::forward<R>(r) }; }
-template<typename R, enableif<isExpr<R>>...> constexpr auto asin(R&& r) -> ArcSinExpr<R> { return { std::forward<R>(r) }; }
-template<typename R, enableif<isExpr<R>>...> constexpr auto acos(R&& r) -> ArcCosExpr<R> { return { std::forward<R>(r) }; }
-template<typename R, enableif<isExpr<R>>...> constexpr auto atan(R&& r) -> ArcTanExpr<R> { return { std::forward<R>(r) }; }
+template<typename R, enableif<isExpr<R>>...> constexpr auto sin(R&& r) -> SinExpr<R> { return { r }; }
+template<typename R, enableif<isExpr<R>>...> constexpr auto cos(R&& r) -> CosExpr<R> { return { r }; }
+template<typename R, enableif<isExpr<R>>...> constexpr auto tan(R&& r) -> TanExpr<R> { return { r }; }
+template<typename R, enableif<isExpr<R>>...> constexpr auto asin(R&& r) -> ArcSinExpr<R> { return { r }; }
+template<typename R, enableif<isExpr<R>>...> constexpr auto acos(R&& r) -> ArcCosExpr<R> { return { r }; }
+template<typename R, enableif<isExpr<R>>...> constexpr auto atan(R&& r) -> ArcTanExpr<R> { return { r }; }
 
 //=====================================================================================================================
 //
@@ -870,9 +870,9 @@ template<typename R, enableif<isExpr<R>>...> constexpr auto atan(R&& r) -> ArcTa
 //
 //=====================================================================================================================
 
-template<typename R, enableif<isExpr<R>>...> constexpr auto sinh(R&& r) -> SinhExpr<R> { return { std::forward<R>(r) }; }
-template<typename R, enableif<isExpr<R>>...> constexpr auto cosh(R&& r) -> CoshExpr<R> { return { std::forward<R>(r) }; }
-template<typename R, enableif<isExpr<R>>...> constexpr auto tanh(R&& r) -> TanhExpr<R> { return { std::forward<R>(r) }; }
+template<typename R, enableif<isExpr<R>>...> constexpr auto sinh(R&& r) -> SinhExpr<R> { return { r }; }
+template<typename R, enableif<isExpr<R>>...> constexpr auto cosh(R&& r) -> CoshExpr<R> { return { r }; }
+template<typename R, enableif<isExpr<R>>...> constexpr auto tanh(R&& r) -> TanhExpr<R> { return { r }; }
 
 //=====================================================================================================================
 //
@@ -880,9 +880,9 @@ template<typename R, enableif<isExpr<R>>...> constexpr auto tanh(R&& r) -> TanhE
 //
 //=====================================================================================================================
 
-template<typename R, enableif<isExpr<R>>...> constexpr auto exp(R&& r) -> ExpExpr<R> { return { std::forward<R>(r) }; }
-template<typename R, enableif<isExpr<R>>...> constexpr auto log(R&& r) -> LogExpr<R> { return { std::forward<R>(r) }; }
-template<typename R, enableif<isExpr<R>>...> constexpr auto log10(R&& r) -> Log10Expr<R> { return { std::forward<R>(r) }; }
+template<typename R, enableif<isExpr<R>>...> constexpr auto exp(R&& r) -> ExpExpr<R> { return { r }; }
+template<typename R, enableif<isExpr<R>>...> constexpr auto log(R&& r) -> LogExpr<R> { return { r }; }
+template<typename R, enableif<isExpr<R>>...> constexpr auto log10(R&& r) -> Log10Expr<R> { return { r }; }
 
 //=====================================================================================================================
 //
@@ -890,8 +890,8 @@ template<typename R, enableif<isExpr<R>>...> constexpr auto log10(R&& r) -> Log1
 //
 //=====================================================================================================================
 
-template<typename L, typename R, enableif<isOperable<L, R>>...> constexpr auto pow(L&& l, R&& r) -> PowExpr<L, R> { return { std::forward<L>(l), std::forward<R>(r) }; }
-template<typename R, enableif<isExpr<R>>...> constexpr auto sqrt(R&& r) -> SqrtExpr<R> { return { std::forward<R>(r) }; }
+template<typename L, typename R, enableif<isOperable<L, R>>...> constexpr auto pow(L&& l, R&& r) -> PowExpr<L, R> { return { l, r }; }
+template<typename R, enableif<isExpr<R>>...> constexpr auto sqrt(R&& r) -> SqrtExpr<R> { return { r }; }
 
 //=====================================================================================================================
 //
@@ -899,7 +899,7 @@ template<typename R, enableif<isExpr<R>>...> constexpr auto sqrt(R&& r) -> SqrtE
 //
 //=====================================================================================================================
 
-template<typename R, enableif<isExpr<R>>...> constexpr auto abs(R&& r) -> AbsExpr<R> { return { std::forward<R>(r) }; }
+template<typename R, enableif<isExpr<R>>...> constexpr auto abs(R&& r) -> AbsExpr<R> { return { r }; }
 template<typename R, enableif<isExpr<R>>...> constexpr auto abs2(R&& r) { return std::forward<R>(r) * std::forward<R>(r); }
 template<typename R, enableif<isExpr<R>>...> constexpr auto conj(R&& r) { return std::forward<R>(r); }
 template<typename R, enableif<isExpr<R>>...> constexpr auto real(R&& r) { return std::forward<R>(r); }


### PR DESCRIPTION
This is a fix for issue #62 in which template expression objects were being stored in other expression objects by reference. 

However, the use case in issue #62 still needs to be corrected. 

Consider the following usage of `dual`:

~~~c++
#include <iostream>

#include <autodiff/forward.hpp>
using namespace autodiff;

template <typename T>
auto pow2(T arg)
{
    return arg * arg;
}

int main()
{
    dual x = 2.0;

    dual y = pow2(pow2(x));

    std::cout << y << std::endl;
}
~~~

This application outputs `nan` or produces a segmentation fault. The reason is that argument `arg` in `pow2` is passed by value, so a temporary `dual` is created when calling `pow2(x)` in `main`. 
This temporary `dual` is then captured by reference when creating the template expression node 
`BinaryExpr<MulOp, const dual&, const dual&>`. This expression node is then returned, the temporary destroyed, and a dangling reference issue takes place. 

To correct this usage, one only needs to make sure the template argument `arg` is passed by reference:


~~~c++
template <typename T>
auto pow2(const T& arg)
{
    return arg * arg;
}
~~~

However, if a temporary is passed to `pow2`, for example, `pow2(dual(2.0))`, then the most recommended approach is to used *universal references*:

~~~c++
template <typename T>
auto pow2(T&& arg)
{
    return std::forward<T>(arg) * std::forward<T>(arg);
}
~~~

This will ensure that not a reference to the temporary is stored in the expression object, but a copy itself: `BinaryExpr<MulOp, dual, dual>`.

@ibell You may want to have a look at the above explanation. Unfortunately, using template functions with `dual` needs to be done more carefully, to avoid dangling references. This is not an issue when `dual` numbers are explicitly stated as the return value of functions. When using template, this is not possible (because it destroys the generic purpose of the template function definition) and instead of returning a `dual` number, an expression tree/node object is returned instead, possibly containing references to temporaries in the scope of the function.
