### PR TITLE
[WIP] Improve reverse mode

### DIFF
--- a/autodiff/reverse/memory.hpp
+++ b/autodiff/reverse/memory.hpp
@@ -1,0 +1,102 @@
+//                  _  _
+//  _   _|_ _  _|o_|__|_
+// (_||_||_(_)(_|| |  |
+//
+// automatic differentiation made easier in C++
+// https://github.com/autodiff/autodiff
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+//
+// Copyright (c) 2018-2019 Allan Leal
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+#include <memory_resource>
+#include <array>
+
+namespace autodiff::reverse {
+/// @brief memory managment for <code> autodiff::reverse </code> algorthms
+namespace memory {
+
+/// @brief stack_resource to allocate memory on stack
+/// @details
+/// stack_resource conatin <code> std::array </code> where we take memory
+/// memory will free when dtor called
+/// and cursor which points on free memory in <code> std::array </code> 
+/// <br>
+/// @todo do we always need to check capacity ? 
+/// @tparam Size count of bytes which we will allocate
+template<std::size_t Size>
+class stack_resource final : public std::pmr::memory_resource 
+{
+    static_assert(Size != 0 && "We can't create resource with Size = 0");
+    using void_t = void;
+public:
+    /// do allocation of memory
+    /// @details
+    /// @param bytes bytes count to allocate
+    /// @param alignment unused
+    /// @return <code> void_t* </code> pointer to memory block
+    void_t* do_allocate(std::size_t bytes, std::size_t alignment = alignof(std::max_align_t) [[maybe_unused]]) override
+    {
+        check_capacity(bytes);
+        void_t* resource = static_cast<void_t*>(storage.data() + cursor);  
+        cursor += bytes;
+        return resource;
+    }
+    /// do deallocation of memory
+    /// @details
+    /// just override base class method
+    /// @param pointer unused
+    /// @param bytes unused
+    /// @param alignment unused
+    void do_deallocate(void_t* pointer [[maybe_unused]], size_t bytes [[maybe_unused]], size_t alignment [[maybe_unused]]) noexcept override { }
+    /// do check of equality
+    /// @details
+    /// @param other other memory_resource
+    /// @return <code> true </code> if <code> other </code> and 
+    /// <code> *this </code> have same adress
+    bool do_is_equal(const memory_resource& other) const noexcept override
+    {
+        return std::addressof(*this) == std::addressof(other);
+    }
+    /// position of memory block
+    /// @details
+    /// @return cursor on current memory block
+    std::size_t position() const noexcept 
+    {
+        return cursor;
+    }
+private:
+    /// check storage capacity
+    /// @details
+    /// throws exception when lack of memory
+    /// @param bytes bytes count to allocate
+    void check_capacity(std::size_t bytes) const noexcept(false)
+    {
+        if(bytes + cursor > Size)
+            throw std::runtime_error("Stack storage too small for your necessities");
+    }
+
+    std::size_t cursor = { 0 };     ///< cursor to free memory
+    std::array<char, Size> storage; ///< memory storage
+};
+}
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,5 +3,6 @@ add_library(catch OBJECT catch.hpp catch.cpp)
 add_executable(tests
     forward.test.cpp
     reverse.test.cpp
+    reverse.memory.test.cpp
     $<TARGET_OBJECTS:catch>)
 target_include_directories(tests PUBLIC ${CMAKE_SOURCE_DIR} ${EIGEN3_INCLUDE_DIR})

--- a/test/reverse.memory.test.cpp
+++ b/test/reverse.memory.test.cpp
@@ -1,0 +1,83 @@
+// Catch includes
+#include "catch.hpp"
+
+// STL include
+#include <memory>
+
+// Autodiff include
+#include <autodiff/reverse/memory.hpp>
+
+using namespace autodiff::reverse::memory;
+
+TEST_CASE("Test stack_resource")
+{
+    SECTION("position is zero after creation of resource")
+    {
+        constexpr auto size = 10u * sizeof(int);
+        stack_resource<size> resource;
+        REQUIRE(resource.position() == 0);
+    }
+
+    SECTION("position changed after allocation on correct size")
+    {
+        constexpr auto size = 10u * sizeof(int);
+        stack_resource<size> resource;
+        auto* p = resource.allocate(sizeof(int));
+        (void)p;
+        REQUIRE(resource.position() == sizeof(int));
+    }
+
+    SECTION("pointer is not equal nullptr after do_allocate")
+    {
+        constexpr auto size = 10u * sizeof(int);
+        stack_resource<size> resource;
+        auto* p = resource.allocate(sizeof(int));
+        REQUIRE(p != nullptr);
+    }
+
+    SECTION("pointers are not equal after next allocation")
+    {
+        constexpr auto size = 10u * sizeof(int);
+        stack_resource<size> resource;
+        auto* p_first = resource.allocate(sizeof(int));
+        auto* p_second = resource.allocate(sizeof(int));
+        REQUIRE(p_first != p_second);
+    }
+
+    SECTION("allocte_shared via stack_resource don't return nullptr")
+    {
+        constexpr auto size = 10u * sizeof(int);
+        stack_resource<size> resource;
+
+        std::pmr::polymorphic_allocator<int> allocator { &resource };
+
+        auto int_ptr = std::allocate_shared<int>(allocator, 42);
+
+        REQUIRE(int_ptr != nullptr);
+    }
+
+    SECTION("allocte_shared via stack_resource contain correct value")
+    {
+        constexpr auto size = 10u * sizeof(int);
+        stack_resource<size> resource;
+
+        std::pmr::polymorphic_allocator<int> allocator{ &resource };
+
+        auto expected_value = 42;
+        auto int_ptr = std::allocate_shared<int>(allocator, expected_value);
+
+        REQUIRE(*int_ptr == expected_value);
+    }
+
+    SECTION("allocte_shared via stack_resource throws exceprion when lack of memory")
+    {
+        // To allocate int as shared we need sizeof(int) + sizeof(control_block) 
+        constexpr auto size = 1u * sizeof(int);
+        stack_resource<size> resource;
+
+        std::pmr::polymorphic_allocator<int> allocator{ &resource };
+
+        REQUIRE_THROWS_WITH(std::allocate_shared<int>(allocator, 42), "Stack storage too small for your necessities");
+    }
+
+}


### PR DESCRIPTION
This PR should improve performance when using `autodiff::reverse` algorithm.
It's just a part of work. See the task list below.

- [x]  make allocation on the stack.
- [ ] make enable to allocate expression nodes using allocator.
- [ ] add benchmarking. 
- [ ] compare stack allocation and pool (on heap).