### PR TITLE
added ScalarBinaryOpTraits for var and double

### DIFF
--- a/autodiff/reverse/eigen.hpp
+++ b/autodiff/reverse/eigen.hpp
@@ -39,19 +39,31 @@ struct NumTraits;
 
 template<> struct NumTraits<autodiff::var> : NumTraits<double> // permits to get the epsilon, dummy_precision, lowest, highest functions
 {
-    typedef autodiff::var Real;
-    typedef autodiff::var NonInteger;
-    typedef autodiff::var Nested;
-    enum
+  typedef autodiff::var Real;
+  typedef autodiff::var NonInteger;
+  typedef autodiff::var Nested;
+  enum
     {
-        IsComplex = 0,
-        IsInteger = 0,
-        IsSigned = 1,
-        RequireInitialization = 1,
-        ReadCost = 1,
-        AddCost = 3,
-        MulCost = 3
+      IsComplex = 0,
+      IsInteger = 0,
+      IsSigned = 1,
+      RequireInitialization = 1,
+      ReadCost = 1,
+      AddCost = 3,
+      MulCost = 3
     };
+};
+
+template<typename BinOp>
+struct ScalarBinaryOpTraits<autodiff::var, double, BinOp>
+{
+  typedef autodiff::var ReturnType;
+};
+
+template<typename BinOp>
+struct ScalarBinaryOpTraits<double, autodiff::var, BinOp>
+{
+    typedef autodiff::var ReturnType;
 };
 
 #define EIGEN_MAKE_TYPEDEFS(Type, TypeSuffix, Size, SizeSuffix)   \
@@ -112,5 +124,3 @@ Eigen::MatrixXd hessian(const var& y, const vars& x)
 }
 
 } // namespace autodiff
-
-


### PR DESCRIPTION
This PR allows for mixing VectorXvar and VectorXd types in element-wise binary operations such as
```c++
VectorXvar x(3); x << 1.0, 2.0, 3.0;
VectorXd y(3); x << 2.0, 2.0, 2.0;
x+y;
x-y;
x*y;
x.cwiseQuotient(y);
```
This is a fix for issue #81 
