### PR TITLE
Erf forwards

### DIFF
--- a/autodiff/forward/forward.hpp
+++ b/autodiff/forward/forward.hpp
@@ -60,6 +60,7 @@ using std::tan;
 using std::cosh;
 using std::sinh;
 using std::tanh;
+using std::erf;
 
 //=====================================================================================================================
 //
@@ -83,9 +84,9 @@ struct InvOp    {};  // INVERSE OPERATOR
 struct SinOp    {};  // SINE OPERATOR
 struct CosOp    {};  // COSINE OPERATOR
 struct TanOp    {};  // TANGENT OPERATOR
-struct SinhOp    {};  // HYPERBOLIC SINE OPERATOR
-struct CoshOp    {};  // HYPERBOLIC COSINE OPERATOR
-struct TanhOp    {};  // HYPERBOLIC TANGENT OPERATOR
+struct SinhOp   {};  // HYPERBOLIC SINE OPERATOR
+struct CoshOp   {};  // HYPERBOLIC COSINE OPERATOR
+struct TanhOp   {};  // HYPERBOLIC TANGENT OPERATOR
 struct ArcSinOp {};  // ARC SINE OPERATOR
 struct ArcCosOp {};  // ARC COSINE OPERATOR
 struct ArcTanOp {};  // ARC TANGENT OPERATOR
@@ -95,6 +96,7 @@ struct Log10Op  {};  // BASE-10 LOGARITHM OPERATOR
 struct SqrtOp   {};  // SQUARE ROOT OPERATOR
 struct PowOp    {};  // POWER OPERATOR
 struct AbsOp    {};  // ABSOLUTE OPERATOR
+struct ErfOp    {};  // ERROR FUNCTION OPERATOR
 
 //-----------------------------------------------------------------------------
 // OTHER OPERATORS
@@ -179,6 +181,9 @@ using PowExpr = BinaryExpr<PowOp, L, R>;
 
 template<typename R>
 using AbsExpr = UnaryExpr<AbsOp, R>;
+
+template<typename R>
+using ErfExpr = UnaryExpr<ErfOp, R>;
 
 //-----------------------------------------------------------------------------
 // DERIVED ARITHMETIC EXPRESSIONS
@@ -933,6 +938,7 @@ template<typename R, enableif<isExpr<R>>...> constexpr auto abs2(R&& r) { return
 template<typename R, enableif<isExpr<R>>...> constexpr auto conj(R&& r) { return std::forward<R>(r); }
 template<typename R, enableif<isExpr<R>>...> constexpr auto real(R&& r) { return std::forward<R>(r); }
 template<typename R, enableif<isExpr<R>>...> constexpr auto imag(R&& r) { return 0.0; }
+template<typename R, enableif<isExpr<R>>...> constexpr auto erf(R&& r) -> ErfExpr<R> { return { r }; }
 
 //=====================================================================================================================
 //
@@ -1485,6 +1491,15 @@ constexpr void apply(Dual<T, G>& self, AbsOp)
     const T aux = self.val;
     self.val = abs(self.val);
     self.grad *= aux / self.val;
+}
+
+template<typename T, typename G>
+constexpr void apply(Dual<T, G>& self, ErfOp)
+{
+    constexpr double pi = 3.1415926535897932384626433832795029;
+    const T aux = self.val;
+    self.val = erf(aux);
+    self.grad *= 2.0 * exp(-aux*aux)/sqrt(pi);
 }
 
 template<typename Op, typename T, typename G>

--- a/autodiff/forward/forward.hpp
+++ b/autodiff/forward/forward.hpp
@@ -1496,10 +1496,10 @@ constexpr void apply(Dual<T, G>& self, AbsOp)
 template<typename T, typename G>
 constexpr void apply(Dual<T, G>& self, ErfOp)
 {
-    constexpr double pi = 3.1415926535897932384626433832795029;
+    constexpr auto sqrt_pi = 1.7724538509055160272981674833411451872554456638435; // TODO: In the new version, use type NumericType<T> instead of auto.
     const T aux = self.val;
     self.val = erf(aux);
-    self.grad *= 2.0 * exp(-aux*aux)/sqrt(pi);
+    self.grad *= 2.0 * exp(-aux*aux)/sqrt_pi;
 }
 
 template<typename Op, typename T, typename G>

--- a/test/forward.test.cpp
+++ b/test/forward.test.cpp
@@ -614,8 +614,8 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         REQUIRE( f(x) == std::abs(val(x)) );
         REQUIRE( derivative(f, wrt(x), at(x)) == approx(-1.0) );
 
-	// Testing erf function
-	f = [](dual x) -> dual { return erf(x); };
+        // Testing erf function
+        f = [](dual x) -> dual { return erf(x); };
         x = 1.0;
         REQUIRE( f(x) == std::erf(val(x)) );
         REQUIRE( derivative(f, wrt(x), at(x)) == approx(0.415107) );
@@ -749,24 +749,6 @@ TEST_CASE("Eigen::VectorXdual tests", "[dual]")
         REQUIRE( g[1] == approx(x[1]) );
         REQUIRE( g[2] == approx(x[2]) );
     }
-
-    SECTION("testing gradient derivatives with Erf")
-    {
-        auto f = [](const VectorXdual& x) -> dual
-        {
-            return erf(x.array()).sum();
-        };
-
-        VectorXdual x(3);
-        x << 0.0, 0.5, 1.0;
-
-        VectorXd g = gradient(f, wrt(x), at(x));
-
-        REQUIRE( g[0] == approx( 1.12838  ) );
-        REQUIRE( g[1] == approx( 0.878783 ) );
-        REQUIRE( g[2] == approx( 0.415107 ) );
-    }
-
 
     SECTION("testing gradient derivatives of only the last two variables")
     {

--- a/test/forward.test.cpp
+++ b/test/forward.test.cpp
@@ -6,7 +6,7 @@
 using namespace Eigen;
 
 // For Special functions like Erf
-#include <unsupported/Eigen/SpecialFunctions>
+#include <eigen3/unsupported/Eigen/SpecialFunctions>
 
 // autodiff includes
 #include <autodiff/forward.hpp>

--- a/test/forward.test.cpp
+++ b/test/forward.test.cpp
@@ -5,6 +5,9 @@
 #include <Eigen/Core>
 using namespace Eigen;
 
+// For Special functions like Erf
+#include <unsupported/Eigen/SpecialFunctions>
+
 // autodiff includes
 #include <autodiff/forward.hpp>
 #include <autodiff/forward/eigen.hpp>
@@ -610,6 +613,15 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         x = -1.0;
         REQUIRE( f(x) == std::abs(val(x)) );
         REQUIRE( derivative(f, wrt(x), at(x)) == approx(-1.0) );
+
+	// Testing erf function
+	f = [](dual x) -> dual { return erf(x); };
+        x = 1.0;
+        REQUIRE( f(x) == std::erf(val(x)) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(0.415107) );
+        x = -1.4;
+        REQUIRE( f(x) == std::erf(val(x)) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(0.158942) );
     }
 
     SECTION("testing complex expressions")
@@ -738,6 +750,24 @@ TEST_CASE("Eigen::VectorXdual tests", "[dual]")
         REQUIRE( g[2] == approx(x[2]) );
     }
 
+    SECTION("testing gradient derivatives with Erf")
+    {
+        auto f = [](const VectorXdual& x) -> dual
+        {
+            return erf(x.array()).sum();
+        };
+
+        VectorXdual x(3);
+        x << 0.0, 0.5, 1.0;
+
+        VectorXd g = gradient(f, wrt(x), at(x));
+
+        REQUIRE( g[0] == approx( 1.12838  ) );
+        REQUIRE( g[1] == approx( 0.878783 ) );
+        REQUIRE( g[2] == approx( 0.415107 ) );
+    }
+
+
     SECTION("testing gradient derivatives of only the last two variables")
     {
         // Testing complex function involving sin and cos
@@ -826,14 +856,14 @@ TEST_CASE("Eigen::VectorXdual tests", "[dual]")
 
         VectorXdual x(3);
         x << 1.0, 2.0, 3.0;
-        
+
         dual y = 2;
-   
+
         VectorXdual z(4);
         z << 1.0, 2.0, 3.0, 4.0;
 
         VectorXd g = gradient(f, wrtpack(x.tail(2), y, z), at(x, y, z));
-        
+
         REQUIRE( g.size() == 7 );
     }
 
@@ -846,14 +876,14 @@ TEST_CASE("Eigen::VectorXdual tests", "[dual]")
 
         VectorXdual x(2);
         x << 1.0, 2.0;
-        
+
         dual y = 3.0;
-   
+
         VectorXdual z(1);
         z << 4.0;
 
         VectorXd g = gradient(f, wrtpack(x, y, z), at(x, y, z));
-        
+
         REQUIRE(g[0] == approx(x[0]));
         REQUIRE(g[1] == approx(x[1]));
         REQUIRE(g[2] == approx(y));
@@ -867,7 +897,7 @@ TEST_CASE("Eigen::VectorXdual tests", "[dual]")
             VectorXdual ret(x.size() + z.size());
             ret.head(x.size()) = x * y / x.array().sum();
             ret.tail(z.size()) = y * z;
-            
+
             return ret;
         };
 


### PR DESCRIPTION
This PR adds Erf to forwards mode with a test.

Note that Erf (and other special functions) in Eigen are UnaryOps which apply to array objects, e.g:
```c++ 
VectorXdual x; 
erf(x.array());
```
Some special math functions are in the Eigen header (cf [Eigen bugzilla](https://eigen.tuxfamily.org/bz/show_bug.cgi?id=1775)):
``
 #include <unsupported/Eigen/SpecialFunctions>
``