### PR TITLE
Make autodiff forward friendly with custom numbers

### DIFF
--- a/autodiff/forward/forward.hpp
+++ b/autodiff/forward/forward.hpp
@@ -345,6 +345,9 @@ struct isNumberDualDualMulExpr<NumberDualDualMulExpr<L, C, R>> { constexpr stati
 
 } // namespace traits
 
+template<typename T, typename U>
+constexpr bool isConvertible = std::is_convertible<plain<T>, U>::value;
+
 template<typename T>
 constexpr bool isNumber = std::is_arithmetic<plain<T>>::value;
 
@@ -480,8 +483,9 @@ struct Dual
 
     explicit operator T() const { return this->val; }
 
-    Dual(const ValueType<T>& val)
-    : val(val), grad(0)
+    template<typename U, enableif<isConvertible<U, T> && !isExpr<U>>...>
+    Dual(U&& val)
+    : val(std::forward<U>(val)), grad(0)
     {
     }
 

--- a/autodiff/forward/forward.hpp
+++ b/autodiff/forward/forward.hpp
@@ -227,6 +227,13 @@ using common = typename std::common_type<A, B>::type;
 namespace traits {
 
 //-----------------------------------------------------------------------------
+// IS TYPE T A NUMBER?
+//-----------------------------------------------------------------------------
+template<typename T>
+struct isArithmetic : std::conditional_t<std::is_arithmetic_v<T>, std::true_type,
+std::false_type> { };
+
+//-----------------------------------------------------------------------------
 // IS TYPE T AN EXPRESSION NODE?
 //-----------------------------------------------------------------------------
 template<typename T>
@@ -349,7 +356,7 @@ template<typename T, typename U>
 constexpr bool isConvertible = std::is_convertible<plain<T>, U>::value;
 
 template<typename T>
-constexpr bool isNumber = std::is_arithmetic<plain<T>>::value;
+constexpr bool isArithmetic = traits::isArithmetic<plain<T>>::value;
 
 template<typename T>
 constexpr bool isExpr = traits::isExpr<plain<T>>::value;
@@ -391,7 +398,7 @@ constexpr bool isNumberDualDualMulExpr = traits::isNumberDualDualMulExpr<plain<T
 // ARE TYPES L AND R EXPRESSION NODES OR NUMBERS, BUT NOT BOTH NUMBERS?
 //-----------------------------------------------------------------------------
 template<typename L, typename R>
-constexpr bool isOperable = (isExpr<L> && isExpr<R>) || (isNumber<L> && isExpr<R>) || (isExpr<L> && isNumber<R>);
+constexpr bool isOperable = (isExpr<L> && isExpr<R>) || (isArithmetic<L> && isExpr<R>) || (isExpr<L> && isArithmetic<R>);
 
 namespace traits {
 
@@ -402,7 +409,7 @@ namespace traits {
 struct ValueTypeInvalid {};
 
 template<typename T>
-struct ValueType { using type = std::conditional_t<isNumber<T>, T, ValueTypeInvalid>; };
+struct ValueType { using type = std::conditional_t<forward::isArithmetic<T>, T, ValueTypeInvalid>; };
 
 template<typename T, typename G>
 struct ValueType<Dual<T, G>> { using type = typename ValueType<plain<T>>::type; };
@@ -423,7 +430,7 @@ struct ValueType<TernaryExpr<Op, L, C, R>> { using type = common<typename ValueT
 struct GradTypeInvalid {};
 
 template<typename T>
-struct GradType { using type = std::conditional_t<isNumber<T>, T, GradTypeInvalid>; };
+struct GradType { using type = std::conditional_t<forward::isArithmetic<T>, T, GradTypeInvalid>; };
 
 template<typename T, typename G>
 struct GradType<Dual<T, G>> { using type = typename GradType<plain<G>>::type; };
@@ -504,7 +511,7 @@ struct Dual
         return *this;
     }
 
-    template<typename U, enableif<isNumber<U> || isExpr<U>>...>
+    template<typename U, enableif<isArithmetic<U> || isExpr<U>>...>
     Dual& operator+=(U&& other)
     {
         Dual tmp;
@@ -513,7 +520,7 @@ struct Dual
         return *this;
     }
 
-    template<typename U, enableif<isNumber<U> || isExpr<U>>...>
+    template<typename U, enableif<isArithmetic<U> || isExpr<U>>...>
     Dual& operator-=(U&& other)
     {
         Dual tmp;
@@ -522,7 +529,7 @@ struct Dual
         return *this;
     }
 
-    template<typename U, enableif<isNumber<U> || isExpr<U>>...>
+    template<typename U, enableif<isArithmetic<U> || isExpr<U>>...>
     Dual& operator*=(U&& other)
     {
         Dual tmp;
@@ -531,7 +538,7 @@ struct Dual
         return *this;
     }
 
-    template<typename U, enableif<isNumber<U> || isExpr<U>>...>
+    template<typename U, enableif<isArithmetic<U> || isExpr<U>>...>
     Dual& operator/=(U&& other)
     {
         Dual tmp;
@@ -746,7 +753,7 @@ using PreventExprRef = std::conditional_t<isDual<T>, T, plain<T>>;
 template<typename U>
 constexpr auto negative(U&& expr)
 {
-    static_assert(isExpr<U> || isNumber<U>);
+    static_assert(isExpr<U> || isArithmetic<U>);
     if constexpr (isNegExpr<U>)
         return inner(expr);
     else return NegExpr<PreventExprRef<U>>{ expr };
@@ -820,7 +827,7 @@ constexpr auto operator+(L&& l, R&& r)
     if constexpr (isNegExpr<L> && isNegExpr<R>)
         return -( inner(l) + inner(r) );
     // ADDITION EXPRESSION CASE: expr + number => number + expr (number always on the left)
-    else if constexpr (isExpr<L> && isNumber<R>)
+    else if constexpr (isExpr<L> && isArithmetic<R>)
         return std::forward<R>(r) + std::forward<L>(l);
     // DEFAULT ADDITION EXPRESSION
     else return AddExpr<PreventExprRef<L>, PreventExprRef<R>>{ l, r };
@@ -842,16 +849,16 @@ constexpr auto operator*(L&& l, R&& r)
     else if constexpr (isInvExpr<L> && isInvExpr<R>)
         return inverse(inner(l) * inner(r));
     // // MULTIPLICATION EXPRESSION CASE: expr * number => number * expr
-    else if constexpr (isExpr<L> && isNumber<R>)
+    else if constexpr (isExpr<L> && isArithmetic<R>)
         return std::forward<R>(r) * std::forward<L>(l);
     // // MULTIPLICATION EXPRESSION CASE: number * (-expr) => (-number) * expr
-    else if constexpr (isNumber<L> && isNegExpr<R>)
+    else if constexpr (isArithmetic<L> && isNegExpr<R>)
         return (-l) * inner(r);
     // // MULTIPLICATION EXPRESSION CASE: number * (number * expr) => (number * number) * expr
-    else if constexpr (isNumber<L> && isNumberDualMulExpr<R>)
+    else if constexpr (isArithmetic<L> && isNumberDualMulExpr<R>)
         return (l * left(r)) * right(r);
     // MULTIPLICATION EXPRESSION CASE: number * dual => NumberDualMulExpr
-    else if constexpr (isNumber<L> && isDual<R>)
+    else if constexpr (isArithmetic<L> && isDual<R>)
         return NumberDualMulExpr<PreventExprRef<L>, PreventExprRef<R>>{ l, r };
     // DEFAULT MULTIPLICATION EXPRESSION: expr * expr => MulExpr
     else return MulExpr<PreventExprRef<L>, PreventExprRef<R>>{ l, r };
@@ -884,7 +891,7 @@ constexpr auto operator-(L&& l, R&& r)
 template<typename L, typename R, enableif<isOperable<L, R>>...>
 constexpr auto operator/(L&& l, R&& r)
 {
-    if constexpr (isNumber<R>)
+    if constexpr (isArithmetic<R>)
         return std::forward<L>(l) * (One<L> / std::forward<R>(r));
     else return std::forward<L>(l) * inverse(std::forward<R>(r));
 }
@@ -994,10 +1001,10 @@ constexpr void apply(Dual<T, G>& self);
 template<typename T, typename G, typename U>
 constexpr void assign(Dual<T, G>& self, U&& other)
 {
-    static_assert(isExpr<U> || isNumber<U>);
+    static_assert(isExpr<U> || isArithmetic<U>);
 
     // ASSIGN A NUMBER: self = number
-    if constexpr (isNumber<U>) {
+    if constexpr (isArithmetic<U>) {
         self.val = other;
         self.grad = Zero<T>;
     }
@@ -1037,7 +1044,7 @@ constexpr void assign(Dual<T, G>& self, U&& other)
 template<typename T, typename G, typename U>
 constexpr void assign(Dual<T, G>& self, U&& other, Dual<T, G>& tmp)
 {
-    static_assert(isExpr<U> || isNumber<U>);
+    static_assert(isExpr<U> || isArithmetic<U>);
 
     // ASSIGN AN UNARY EXPRESSION: self = func(expr)
     if constexpr (isUnaryExpr<U>) {
@@ -1076,10 +1083,10 @@ constexpr void assign(Dual<T, G>& self, U&& other, Dual<T, G>& tmp)
 template<typename T, typename G, typename U>
 constexpr void assignAdd(Dual<T, G>& self, U&& other)
 {
-    static_assert(isExpr<U> || isNumber<U>);
+    static_assert(isExpr<U> || isArithmetic<U>);
 
     // ASSIGN-ADD A NUMBER: self += number
-    if constexpr (isNumber<U>) {
+    if constexpr (isArithmetic<U>) {
         self.val += other;
     }
     // ASSIGN-ADD A DUAL NUMBER: self += dual
@@ -1111,7 +1118,7 @@ constexpr void assignAdd(Dual<T, G>& self, U&& other)
 template<typename T, typename G, typename U>
 constexpr void assignAdd(Dual<T, G>& self, U&& other, Dual<T, G>& tmp)
 {
-    static_assert(isExpr<U> || isNumber<U>);
+    static_assert(isExpr<U> || isArithmetic<U>);
 
     // ASSIGN-ADD A NEGATIVE EXPRESSION: self += -expr => self -= expr
     if constexpr (isNegExpr<U>) {
@@ -1138,10 +1145,10 @@ constexpr void assignAdd(Dual<T, G>& self, U&& other, Dual<T, G>& tmp)
 template<typename T, typename G, typename U>
 constexpr void assignSub(Dual<T, G>& self, U&& other)
 {
-    static_assert(isExpr<U> || isNumber<U>);
+    static_assert(isExpr<U> || isArithmetic<U>);
 
     // ASSIGN-SUBTRACT A NUMBER: self -= number
-    if constexpr (isNumber<U>) {
+    if constexpr (isArithmetic<U>) {
         self.val -= other;
     }
     // ASSIGN-SUBTRACT A DUAL NUMBER: self -= dual
@@ -1173,7 +1180,7 @@ constexpr void assignSub(Dual<T, G>& self, U&& other)
 template<typename T, typename G, typename U>
 constexpr void assignSub(Dual<T, G>& self, U&& other, Dual<T, G>& tmp)
 {
-    static_assert(isExpr<U> || isNumber<U>);
+    static_assert(isExpr<U> || isArithmetic<U>);
 
     // ASSIGN-SUBTRACT A NEGATIVE EXPRESSION: self -= -expr => self += expr
     if constexpr (isNegExpr<U>) {
@@ -1200,10 +1207,10 @@ constexpr void assignSub(Dual<T, G>& self, U&& other, Dual<T, G>& tmp)
 template<typename T, typename G, typename U>
 constexpr void assignMul(Dual<T, G>& self, U&& other)
 {
-    static_assert(isExpr<U> || isNumber<U>);
+    static_assert(isExpr<U> || isArithmetic<U>);
 
     // ASSIGN-MULTIPLY A NUMBER: self *= number
-    if constexpr (isNumber<U>) {
+    if constexpr (isArithmetic<U>) {
         self.val *= other;
         self.grad *= other;
     }
@@ -1239,7 +1246,7 @@ constexpr void assignMul(Dual<T, G>& self, U&& other)
 template<typename T, typename G, typename U>
 constexpr void assignMul(Dual<T, G>& self, U&& other, Dual<T, G>& tmp)
 {
-    static_assert(isExpr<U> || isNumber<U>);
+    static_assert(isExpr<U> || isArithmetic<U>);
 
     // ASSIGN-MULTIPLY A NEGATIVE EXPRESSION: self *= (-expr)
     if constexpr (isNegExpr<U>) {
@@ -1267,10 +1274,10 @@ constexpr void assignMul(Dual<T, G>& self, U&& other, Dual<T, G>& tmp)
 template<typename T, typename G, typename U>
 constexpr void assignDiv(Dual<T, G>& self, U&& other)
 {
-    static_assert(isExpr<U> || isNumber<U>);
+    static_assert(isExpr<U> || isArithmetic<U>);
 
     // ASSIGN-DIVIDE A NUMBER: self /= number
-    if constexpr (isNumber<U>) {
+    if constexpr (isArithmetic<U>) {
         self.val /= other;
         self.grad /= other;
     }
@@ -1310,7 +1317,7 @@ constexpr void assignDiv(Dual<T, G>& self, U&& other)
 template<typename T, typename G, typename U>
 constexpr void assignDiv(Dual<T, G>& self, U&& other, Dual<T, G>& tmp)
 {
-    static_assert(isExpr<U> || isNumber<U>);
+    static_assert(isExpr<U> || isArithmetic<U>);
 
     // ASSIGN-DIVIDE A NEGATIVE EXPRESSION: self /= (-expr)
     if constexpr (isNegExpr<U>) {
@@ -1343,7 +1350,7 @@ template<typename T, typename G, typename U>
 constexpr void assignPow(Dual<T, G>& self, U&& other)
 {
     // ASSIGN-POW A NUMBER: self = pow(self, number)
-    if constexpr (isNumber<U>) {
+    if constexpr (isArithmetic<U>) {
         const T aux = pow(self.val, other - 1);
         self.grad *= other * aux;
         self.val = aux * self.val;

--- a/autodiff/forward/forward.hpp
+++ b/autodiff/forward/forward.hpp
@@ -772,13 +772,19 @@ constexpr auto inverse(U&& expr)
 }
 
 //-----------------------------------------------------------------------------
-// AUXILIARY CONSTEXPR CONSTANTS
+// AUXILIARY CONSTEXPR FUNCTIONS TO GET CONSTANTS
 //-----------------------------------------------------------------------------
 template<typename U>
-constexpr auto Zero = static_cast<ValueType<U>>(0);
+constexpr auto Zero()
+{
+    return static_cast<ValueType<U>>(0);
+}
 
 template<typename U>
-constexpr auto One = static_cast<ValueType<U>>(1);
+constexpr auto One()
+{
+    return static_cast<ValueType<U>>(1);
+}
 
 //=====================================================================================================================
 //
@@ -892,7 +898,7 @@ template<typename L, typename R, enableif<isOperable<L, R>>...>
 constexpr auto operator/(L&& l, R&& r)
 {
     if constexpr (isArithmetic<R>)
-        return std::forward<L>(l) * (One<L> / std::forward<R>(r));
+        return std::forward<L>(l) * (One<L>() / std::forward<R>(r));
     else return std::forward<L>(l) * inverse(std::forward<R>(r));
 }
 
@@ -1006,7 +1012,7 @@ constexpr void assign(Dual<T, G>& self, U&& other)
     // ASSIGN A NUMBER: self = number
     if constexpr (isArithmetic<U>) {
         self.val = other;
-        self.grad = Zero<T>;
+        self.grad = Zero<T>();
     }
     // ASSIGN A DUAL NUMBER: self = dual
     else if constexpr (isDual<U>) {
@@ -1283,7 +1289,7 @@ constexpr void assignDiv(Dual<T, G>& self, U&& other)
     }
     // ASSIGN-DIVIDE A DUAL NUMBER: self /= dual
     else if constexpr (isDual<U>) {
-        const T aux = One<T> / other.val; // to avoid aliasing when self === other
+        const T aux = One<T>() / other.val; // to avoid aliasing when self === other
         self.val *= aux;
         self.grad -= self.val * other.grad;
         self.grad *= aux;
@@ -1393,7 +1399,7 @@ constexpr void apply(Dual<T, G>& self, NegOp)
 template<typename T, typename G>
 constexpr void apply(Dual<T, G>& self, InvOp)
 {
-    self.val = One<T> / self.val;
+    self.val = One<T>() / self.val;
     self.grad *= - self.val * self.val;
 }
 
@@ -1414,7 +1420,7 @@ constexpr void apply(Dual<T, G>& self, CosOp)
 template<typename T, typename G>
 constexpr void apply(Dual<T, G>& self, TanOp)
 {
-    const T aux = One<T> / cos(self.val);
+    const T aux = One<T>() / cos(self.val);
     self.val = tan(self.val);
     self.grad *= aux * aux;
 }
@@ -1436,7 +1442,7 @@ constexpr void apply(Dual<T, G>& self, CoshOp)
 template<typename T, typename G>
 constexpr void apply(Dual<T, G>& self, TanhOp)
 {
-    const T aux = One<T> / cosh(self.val);
+    const T aux = One<T>() / cosh(self.val);
     self.val = tanh(self.val);
     self.grad *= aux * aux;
 }
@@ -1444,7 +1450,7 @@ constexpr void apply(Dual<T, G>& self, TanhOp)
 template<typename T, typename G>
 constexpr void apply(Dual<T, G>& self, ArcSinOp)
 {
-    const T aux = One<T> / sqrt(1.0 - self.val * self.val);
+    const T aux = One<T>() / sqrt(1.0 - self.val * self.val);
     self.val = asin(self.val);
     self.grad *= aux;
 }
@@ -1452,7 +1458,7 @@ constexpr void apply(Dual<T, G>& self, ArcSinOp)
 template<typename T, typename G>
 constexpr void apply(Dual<T, G>& self, ArcCosOp)
 {
-    const T aux = -One<T> / sqrt(1.0 - self.val * self.val);
+    const T aux = -One<T>() / sqrt(1.0 - self.val * self.val);
     self.val = acos(self.val);
     self.grad *= aux;
 }
@@ -1460,7 +1466,7 @@ constexpr void apply(Dual<T, G>& self, ArcCosOp)
 template<typename T, typename G>
 constexpr void apply(Dual<T, G>& self, ArcTanOp)
 {
-    const T aux = One<T> / (1.0 + self.val * self.val);
+    const T aux = One<T>() / (1.0 + self.val * self.val);
     self.val = atan(self.val);
     self.grad *= aux;
 }
@@ -1475,7 +1481,7 @@ constexpr void apply(Dual<T, G>& self, ExpOp)
 template<typename T, typename G>
 constexpr void apply(Dual<T, G>& self, LogOp)
 {
-    const T aux = One<T> / self.val;
+    const T aux = One<T>() / self.val;
     self.val = log(self.val);
     self.grad *= aux;
 }
@@ -1484,7 +1490,7 @@ template<typename T, typename G>
 constexpr void apply(Dual<T, G>& self, Log10Op)
 {
     constexpr T ln10 = 2.3025850929940456840179914546843;
-    const T aux = One<T> / (ln10 * self.val);
+    const T aux = One<T>() / (ln10 * self.val);
     self.val = log10(self.val);
     self.grad *= aux;
 }

--- a/examples/forward/example-forward-single-variable-function-custom-scalar.cpp
+++ b/examples/forward/example-forward-single-variable-function-custom-scalar.cpp
@@ -1,0 +1,33 @@
+// C++ includes
+#include <iostream>
+#include <complex>
+using namespace std;
+
+// autodiff include
+#include <autodiff/forward.hpp>
+using namespace autodiff;
+
+// Specialize isNumber for complex to make it compatible with dual
+namespace autodiff::forward::traits {
+template<typename T>
+struct isArithmetic<complex<T>> : std::true_type { };
+} // autodiff::forward::traits
+
+using cxdual = forward::Dual<complex<double>, complex<double>>;
+
+// The single-variable function for which derivatives are needed
+cxdual f(cxdual x)
+{
+    return 1 + x + x*x + 1/x + log(x);
+}
+
+int main()
+{
+    cxdual x = 2.0;   // the input variable x
+    cxdual u = f(x);  // the output variable u
+
+    cxdual dudx = derivative(f, wrt(x), at(x));  // evaluate the derivative du/dx
+
+    cout << "u = " << u << endl;         // print the evaluated output u
+    cout << "du/dx = " << dudx << endl;  // print the evaluated derivative du/dx
+}


### PR DESCRIPTION
# Description
In this PR we make enable to use autodiff dual with custom scalars. Also example is added. Also improved dual construction. Resolve issue #91.
## Details 
- Re-implement constructor with parameter to make enable use implicit construction:
  ```cpp
  using dual_cmpx = forward::Dual<complex<double>, complex<double>>;
  // ...
  dual_cmpx x = 2.0;
  ```
  If we use scalar which can be implicit constructed from e.g. from `double` above code is not legal with 
  implementation:
  ```cpp
  Dual(const ValueType<T>& val)
  : val(val), grad(0)
  {
  }
  ```
  After substitution we have something like this:
  ```cpp
  Dual(const std::complex<double>& val)
  : val(val), grad(0)
  {
  }
  ```
   And this conversation is prevented by standard [see this link](https://stackoverflow.com/a/17348767).
- Added Structure `isNumber` which can be specialized in user code. (Also I thought about checking 
   operators using `decltype + void_t` but not sure if we need it.
- Changed constants `One` and `Zero` to function to avoid failure for non-literals. E.g. [posit](https://github.com/stillwater-sc/universal) is not 
   literal and we can't create constexpr variable from it [see](https://en.cppreference.com/w/cpp/named_req/LiteralType). But constexpr functions can resolve this 
   issue (in some cases they will generate constexpr(e.g. doubles) in other it will be non-constexpr(e.g. 
  posit)