### PR TITLE
Use built-in miniconda from GH action

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,6 +26,8 @@ jobs:
       with:
         auto-update-conda: true
     - name: Install
+      shell: bash -l {0}
       run: bash ci/actions/install.sh
     - name: Tests
+      shell: bash -l {0}
       run: bash ci/actions/test.sh

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -31,4 +31,3 @@ jobs:
       run: bash ci/actions/install.sh
     - name: Tests
       run: bash ci/actions/test.sh
-

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Download and install conda
-      run: |
-        wget -O miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-${{ env.os }}.sh
-        rm -rf $HOME/miniconda
-        bash miniconda.sh -b -p $HOME/miniconda
+    - uses: goanpeca/setup-miniconda@v1.0.2
+      with:
+        auto-update-conda: true
     - name: Install
+      shell: bash -l {0}
       run: bash ci/actions/install.sh
     - name: Tests
+      shell: bash -l {0}
       run: bash ci/actions/test.sh

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,17 +26,17 @@ jobs:
       with:
         auto-update-conda: true
     - name: Install
-      shell: cmd /C CALL {0}
+      shell: powershell
       run: |
         conda install -c conda-forge conda-devenv
         conda info -a
         conda devenv
     - name: Build
-      shell: cmd /C CALL {0}
+      shell: powershell
       run: |
         call activate autodiff
         cmake -S . -B build
         cmake --build build --config ${{ env.configuration }} --target install
     - name: Tests
-      shell: cmd /C CALL {0}
+      shell: powershell
       run: call build\test\${{ env.configuration }}\tests.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,6 +26,7 @@ jobs:
       with:
         auto-update-conda: true
         auto-activate-base: true
+        activate-environment: ''
 #         activate-environment: autodiff
     - name: Install conda-devenv
       shell: powershell

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: goanpeca/setup-miniconda@v1.0.2
       with:
-      auto-update-conda: true
+        auto-update-conda: true
     - name: Build
       shell: powershell
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Install
       shell: cmd /C CALL {0}
       run: |
+        conda config --add channels conda-forge
         conda install conda-devenv
         conda info -a
         conda devenv

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,10 +25,15 @@ jobs:
     - uses: goanpeca/setup-miniconda@v1.0.2
       with:
         auto-update-conda: true
+    - name: Install
+      shell: cmd /C CALL {0}
+      run: |
+        conda install conda-devenv
+        conda info -a
+        conda devenv
     - name: Build
       shell: cmd /C CALL {0}
       run: |
-        conda info --envs
         call activate autodiff
         cmake -S . -B build
         cmake --build build --config ${{ env.configuration }} --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Build
       shell: powershell
       run: |
-        call activate autodiff
+        conda activate autodiff
         cmake -S . -B build
         cmake --build build --config ${{ env.configuration }} --target install
     - name: Tests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,8 +28,7 @@ jobs:
     - name: Install
       shell: cmd /C CALL {0}
       run: |
-        conda config --add channels conda-forge
-        conda install conda-devenv
+        conda install -c conda-forge conda-devenv
         conda info -a
         conda devenv
     - name: Build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,11 +26,11 @@ jobs:
       with:
         auto-update-conda: true
     - name: Build
-      shell: powershell
-      run: |
+      shell: cmd /C CALL {0}
+      run: >-
         call activate autodiff
         cmake -S . -B build
         cmake --build build --config ${{ env.configuration }} --target install
     - name: Tests
-      shell: powershell
+      shell: cmd /C CALL {0}
       run: call build\test\${{ env.configuration }}\tests.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,6 +33,7 @@ jobs:
         conda install -c conda-forge conda-devenv
         conda info -a
         conda devenv
+        conda create -n foo
     - name: Build
       shell: powershell
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,8 +25,8 @@ jobs:
     - uses: goanpeca/setup-miniconda@v1.0.2
       with:
         auto-update-conda: true
-        auto-activate-base: true
-        activate-environment: ''
+#         auto-activate-base: true
+#         activate-environment: ''
     - name: Install conda-devenv
       shell: powershell
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,4 +43,4 @@ jobs:
         cmake --build build --config ${{ env.configuration }} --target install
     - name: Tests
       shell: powershell
-      run: call build\test\${{ env.configuration }}\tests.exe
+      run: .\build\test\${{ env.configuration }}\tests.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,11 +30,10 @@ jobs:
       run: |
         conda install -c conda-forge conda-devenv
         conda info -a
+        conda devenv
     - name: Build
       shell: cmd /C CALL {0}
       run: |
-        conda devenv
-        conda info --envs
         call activate autodiff
         cmake -S . -B build
         cmake --build build --config ${{ env.configuration }} --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,7 +25,8 @@ jobs:
     - uses: goanpeca/setup-miniconda@v1.0.2
       with:
         auto-update-conda: true
-        activate-environment: autodiff
+        auto-activate-base: true
+#         activate-environment: autodiff
     - name: Install conda-devenv
       shell: powershell
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,10 +30,11 @@ jobs:
       run: |
         conda install -c conda-forge conda-devenv
         conda info -a
-        conda devenv
     - name: Build
       shell: cmd /C CALL {0}
       run: |
+        conda devenv
+        conda info --envs
         call activate autodiff
         cmake -S . -B build
         cmake --build build --config ${{ env.configuration }} --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,7 +27,7 @@ jobs:
         auto-update-conda: true
     - name: Build
       shell: cmd /C CALL {0}
-      run: >-
+      run: |
         call activate autodiff
         cmake -S . -B build
         cmake --build build --config ${{ env.configuration }} --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,6 +34,7 @@ jobs:
         conda info -a
         conda devenv
         conda create -n foo
+        conda info --envs
     - name: Build
       shell: powershell
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Build
       shell: cmd /C CALL {0}
       run: |
+        conda info --envs
         call activate autodiff
         cmake -S . -B build
         cmake --build build --config ${{ env.configuration }} --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,8 +23,8 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: goanpeca/setup-miniconda@v1.0.2
-        with:
-        auto-update-conda: true
+      with:
+      auto-update-conda: true
     - name: Build
       shell: powershell
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,16 +25,14 @@ jobs:
     - uses: goanpeca/setup-miniconda@v1.0.2
       with:
         auto-update-conda: true
-#         auto-activate-base: true
-#         activate-environment: ''
+        auto-activate-base: true
+        activate-environment: ''
     - name: Install conda-devenv
       shell: powershell
       run: |
         conda install -c conda-forge conda-devenv
         conda info -a
         conda devenv
-        conda create -n foo
-        conda info --envs
     - name: Build
       shell: powershell
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: goanpeca/setup-miniconda@v1.0.2
       with:
         auto-update-conda: true
-        environment-file: environment.devenv.yml
+        activate-environment: autodiff
     - name: Install conda-devenv
       shell: powershell
       run: |
@@ -35,6 +35,7 @@ jobs:
       shell: powershell
       run: |
         conda devenv
+        conda info --envs
         conda activate autodiff
         cmake -S . -B build
         cmake --build build --config ${{ env.configuration }} --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,6 +34,7 @@ jobs:
       shell: powershell
       run: |
         conda devenv
+        conda info --envs
         conda activate autodiff
         cmake -S . -B build
         cmake --build build --config ${{ env.configuration }} --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,6 +25,7 @@ jobs:
     - uses: goanpeca/setup-miniconda@v1.0.2
       with:
         auto-update-conda: true
+        environment-file: environment.devenv.yml
     - name: Install conda-devenv
       shell: powershell
       run: |
@@ -34,7 +35,6 @@ jobs:
       shell: powershell
       run: |
         conda devenv
-        conda info --envs
         conda activate autodiff
         cmake -S . -B build
         cmake --build build --config ${{ env.configuration }} --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,15 +25,15 @@ jobs:
     - uses: goanpeca/setup-miniconda@v1.0.2
       with:
         auto-update-conda: true
-    - name: Install
+    - name: Install conda-devenv
       shell: powershell
       run: |
         conda install -c conda-forge conda-devenv
         conda info -a
-        conda devenv
     - name: Build
       shell: powershell
       run: |
+        conda devenv
         conda activate autodiff
         cmake -S . -B build
         cmake --build build --config ${{ env.configuration }} --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,17 +27,15 @@ jobs:
         auto-update-conda: true
         auto-activate-base: true
         activate-environment: ''
-#         activate-environment: autodiff
     - name: Install conda-devenv
       shell: powershell
       run: |
         conda install -c conda-forge conda-devenv
         conda info -a
+        conda devenv
     - name: Build
       shell: powershell
       run: |
-        conda devenv
-        conda info --envs
         conda activate autodiff
         cmake -S . -B build
         cmake --build build --config ${{ env.configuration }} --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,23 +22,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Setup conda
-      shell: cmd
-      run: |
-        set PATH=%CONDA%;%CONDA%\Scripts;%CONDA%\Library\bin;%PATH%
-        conda config --set always_yes yes --set changeps1 no
-        conda config --add channels conda-forge
-        conda install conda-devenv
-        conda update -q conda
-        conda info -a
-        conda devenv
+    - uses: goanpeca/setup-miniconda@v1.0.2
+        with:
+        auto-update-conda: true
     - name: Build
-      shell: cmd
+      shell: powershell
       run: |
-        set PATH=%CONDA%;%CONDA%\Scripts;%CONDA%\Library\bin;%PATH%
         call activate autodiff
         cmake -S . -B build
         cmake --build build --config ${{ env.configuration }} --target install
     - name: Tests
-      shell: cmd
+      shell: powershell
       run: call build\test\${{ env.configuration }}\tests.exe

--- a/autodiff/forward/eigen.hpp
+++ b/autodiff/forward/eigen.hpp
@@ -358,4 +358,3 @@ auto hessian(const Function& f, Wrt&& wrt, Args&& args) -> Eigen::MatrixXd
 namespace autodiff {
 using forward::wrtpack;
 }
-

--- a/ci/actions/install.sh
+++ b/ci/actions/install.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-bash "$HOME"/miniconda/etc/profile.d/conda.sh
-export PATH=$HOME/miniconda/bin/:$PATH
 conda config --set always_yes yes --set changeps1 no
 conda config --add channels conda-forge
 conda install conda-devenv

--- a/ci/actions/install.sh
+++ b/ci/actions/install.sh
@@ -6,7 +6,7 @@ conda install conda-devenv
 conda update -q conda
 conda info -a
 conda devenv
-conda activate autodiff
+source activate autodiff
 mkdir build
 cd build || exit
 cmake .. -GNinja

--- a/ci/actions/install.sh
+++ b/ci/actions/install.sh
@@ -1,5 +1,6 @@
+#!/usr/bin/env bash
 
-bash $HOME/miniconda/etc/profile.d/conda.sh
+bash "$HOME"/miniconda/etc/profile.d/conda.sh
 export PATH=$HOME/miniconda/bin/:$PATH
 conda config --set always_yes yes --set changeps1 no
 conda config --add channels conda-forge
@@ -9,6 +10,6 @@ conda info -a
 conda devenv
 source activate autodiff
 mkdir build
-cd build
+cd build || exit
 cmake .. -GNinja
 ninja

--- a/ci/actions/install.sh
+++ b/ci/actions/install.sh
@@ -6,7 +6,7 @@ conda install conda-devenv
 conda update -q conda
 conda info -a
 conda devenv
-source activate autodiff
+conda activate autodiff
 mkdir build
 cd build || exit
 cmake .. -GNinja

--- a/ci/actions/test.sh
+++ b/ci/actions/test.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 ./build/test/tests

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -1,5 +1,6 @@
 name: autodiff
-
+channels:
+  - conda-forge
 dependencies:
   - cmake>=3.13
   - ninja

--- a/examples/forward/example-forward-gradient-derivatives-using-eigen-with-parameters.cpp
+++ b/examples/forward/example-forward-gradient-derivatives-using-eigen-with-parameters.cpp
@@ -29,7 +29,7 @@ int main()
 
     VectorXd gx = gradient(f, wrt(x), at(x, p), u);  // evaluate the function value u and its gradient vector gx = du/dx
     VectorXd gp = gradient(f, wrt(p), at(x, p), u);  // evaluate the function value u and its gradient vector gp = du/dp
-    VectorXd gpx = gradient(f, wrtpack(p, x), at(x, p), u);  // evaluate the function value u and its gradient vector gp = [du/dp, du/dx]  
+    VectorXd gpx = gradient(f, wrtpack(p, x), at(x, p), u);  // evaluate the function value u and its gradient vector gp = [du/dp, du/dx]
 
     cout << "u = " << u << endl;    // print the evaluated output u
     cout << "gx = \n" << gx << endl;  // print the evaluated gradient vector gx = du/dx

--- a/examples/forward/example-forward-gradient-derivatives-using-eigen-with-scalar.cpp
+++ b/examples/forward/example-forward-gradient-derivatives-using-eigen-with-scalar.cpp
@@ -26,7 +26,7 @@ int main()
 
     dual u;  // the output scalar u = f(x, p) evaluated together with gradient below
 
-    VectorXd gpx = gradient(f, wrtpack(p, x), at(x, p), u);  // evaluate the function value u and its gradient vector gp = [du/dp, du/dx]  
+    VectorXd gpx = gradient(f, wrtpack(p, x), at(x, p), u);  // evaluate the function value u and its gradient vector gp = [du/dp, du/dx]
 
     cout << "u = " << u << endl;    // print the evaluated output u
     cout << "gpx = \n" << gpx << endl;  // print the evaluated gradient vector gp = [du/dp, du/dx]

--- a/examples/forward/example-forward-hessian-derivatives-using-eigen-with-scalar.cpp
+++ b/examples/forward/example-forward-hessian-derivatives-using-eigen-with-scalar.cpp
@@ -30,7 +30,7 @@ int main()
     dual2nd u;  // the output scalar u = f(x, p) evaluated together with gradient below
     VectorXd g; // gradient of f(x, p) evaluated together with Hessian below
 
-    VectorXd H = hessian(f, wrtpack(p, x), at(x, p), u, g);  // evaluate the function value u and its gradient vector gp = [du/dp, du/dx]  
+    VectorXd H = hessian(f, wrtpack(p, x), at(x, p), u, g);  // evaluate the function value u and its gradient vector gp = [du/dp, du/dx]
 
     cout << "u = " << u << endl;    // print the evaluated output u
     cout << "Hessian = \n" << H << endl;  // print the evaluated gradient vector gp = [du/dp, du/dx]


### PR DESCRIPTION
Hi @allanleal and `autodiff` contributors!

This PR removes `conda` manual installation. Now, using a GitHub Action, `conda` will be used from CI machines.

In summary, this PR is a CI improvement. It solves #96 