### PR TITLE
Allow EIGEN3_INCLUDE_DIR to be provided during cmake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,13 @@ include(GNUInstallDirs)
 # Ensure proper configuration if in a conda environment
 include(CondaAware)
 
-find_package(Eigen3 REQUIRED)
+# Find Eigen3 if its include path is not given
+if(NOT DEFINED EIGEN3_INCLUDE_DIR)
+    find_package(Eigen3 3.3 REQUIRED NO_MODULE)
+endif()
+
+# Show message stating path to Eigen3
+message(STATUS "Using Eigen3 library found at ${EIGEN3_INCLUDE_DIR}")
 
 # autodiff requires a c++17 enabled compiler
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
This PR is to address the need to allow users to specify the path to Eigen3 as follows:

~~~
cd autodiff
mkdir build
cd build
cmake .. -DEIGEN3_INCLUDE_DIR=/path/to/downloaded/eigen-3.3.7
make 
~~~
