### PR TITLE
Fix operator+=, -=, *=, /= for Variable

### DIFF
--- a/autodiff/reverse/reverse.hpp
+++ b/autodiff/reverse/reverse.hpp
@@ -935,19 +935,20 @@ struct Variable
     /// Construct a Variable object with given expression
     Variable(const ExprPtr<T>& expr) : expr(std::make_shared<DependentVariableExpr<T>>(expr)) {}
 
-    auto variableExpr() const { return static_cast<VariableExpr<T>*>(expr.get()); }
+    /// Return a pointer to the underlying VariableExpr object in this variable.
+    auto __variableExpr() const { return static_cast<VariableExpr<T>*>(expr.get()); }
 
     /// Return the derivative value stored in this variable.
-    auto grad() const { return variableExpr()->grad; }
+    auto grad() const { return __variableExpr()->grad; }
 
     /// Return the derivative expression stored in this variable.
-    auto gradx() const { return variableExpr()->gradx; }
+    auto gradx() const { return __variableExpr()->gradx; }
 
     /// Reeet the derivative value stored in this variable to zero.
-    auto seed() { variableExpr()->grad = 0; }
+    auto seed() { __variableExpr()->grad = 0; }
 
     /// Reeet the derivative expression stored in this variable to zero expression.
-    auto seedx() { variableExpr()->gradx = constant<T>(0); }
+    auto seedx() { __variableExpr()->gradx = constant<T>(0); }
 
     /// Implicitly convert this Variable object into an expression pointer.
     operator ExprPtr<T>() const { return expr; }
@@ -957,19 +958,22 @@ struct Variable
 
     /// Assign an arithmetic value to this variable.
     template<typename U, EnableIf<isArithmetic<U>>...>
-    auto operator=(const U& val) -> Variable& { expr->val = val; return *this; }
+    auto operator=(const U& val) -> Variable& { *this = Variable(val); return *this; }
+
+    /// Assign an expression to this variable.
+    auto operator=(const ExprPtr<T>& x) -> Variable& { *this = Variable(x); return *this; }
 
 	// Assignment operators
-    Variable& operator+=(const ExprPtr<T>& x) { expr = expr + x; return *this; }
-    Variable& operator-=(const ExprPtr<T>& x) { expr = expr - x; return *this; }
-    Variable& operator*=(const ExprPtr<T>& x) { expr = expr * x; return *this; }
-    Variable& operator/=(const ExprPtr<T>& x) { expr = expr / x; return *this; }
+    Variable& operator+=(const ExprPtr<T>& x) { *this = Variable(expr + x); return *this; }
+    Variable& operator-=(const ExprPtr<T>& x) { *this = Variable(expr - x); return *this; }
+    Variable& operator*=(const ExprPtr<T>& x) { *this = Variable(expr * x); return *this; }
+    Variable& operator/=(const ExprPtr<T>& x) { *this = Variable(expr / x); return *this; }
 
 	// Assignment operators with arithmetic values
-    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator+=(const U& x) { expr = expr + constant<T>(x); return *this; }
-    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator-=(const U& x) { expr = expr - constant<T>(x); return *this; }
-    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator*=(const U& x) { expr = expr * constant<T>(x); return *this; }
-    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator/=(const U& x) { expr = expr / constant<T>(x); return *this; }
+    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator+=(const U& x) { *this = Variable(expr + x); return *this; }
+    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator-=(const U& x) { *this = Variable(expr - x); return *this; }
+    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator*=(const U& x) { *this = Variable(expr * x); return *this; }
+    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator/=(const U& x) { *this = Variable(expr / x); return *this; }
 };
 
 //------------------------------------------------------------------------------

--- a/test/reverse.test.cpp
+++ b/test/reverse.test.cpp
@@ -93,12 +93,12 @@ TEST_CASE("autodiff::var tests", "[var]")
     REQUIRE( grad(c, x) == 2*val(a) * grad(a, x) + 1 );
 
     //------------------------------------------------------------------------------
-    // TEST DERIVATIVES COMPUTATION REMAINS CORRECT AFTER CHANGING VAR VALUE
+    // TEST DERIVATIVES COMPUTATION AFTER CHANGING VAR VALUE
     //------------------------------------------------------------------------------
-    a = 20.0;
+    a = 20.0; // a is now a new independent variable
 
-    REQUIRE( grad(c, a) == 2*val(a) + grad(x, a) );
-    REQUIRE( grad(c, x) == 2*val(a) * grad(a, x) + 1 );
+    REQUIRE( grad(c, a) == approx(0.0) );
+    REQUIRE( grad(c, x) == 2*val(x) + 1 );
 
     //------------------------------------------------------------------------------
     // TEST MULTIPLICATION OPERATOR (USING CONSTANT FACTOR)
@@ -115,8 +115,55 @@ TEST_CASE("autodiff::var tests", "[var]")
     REQUIRE( grad(c, a) == approx(1.0/3.0) );
 
     //------------------------------------------------------------------------------
+    // TEST DERIVATIVES WITH RESPECT TO DEPENDENT VARIABLES USING += -= *= /=
+    //------------------------------------------------------------------------------
+
+    a += 2.0;
+    c = a * b;
+
+    REQUIRE( grad(c, a) == approx(b) );
+
+    a -= 3.0;
+    c = a * b;
+
+    REQUIRE( grad(c, a) == approx(b) );
+
+    a *= 2.0;
+    c = a * b;
+
+    REQUIRE( grad(c, a) == approx(b) );
+
+    a /= 3.0;
+    c = a * b;
+
+    REQUIRE( grad(c, a) == approx(b) );
+
+    a += 2*b;
+    c = a * b;
+
+    REQUIRE( grad(c, a) == approx(b + a * grad(b, a)) );
+
+    // a -= 3*b;
+    // c = a * b;
+
+    // REQUIRE( grad(c, a) == approx(b) );
+
+    // a *= b;
+    // c = a * b;
+
+    // REQUIRE( grad(c, a) == approx(b) );
+
+    // a /= b;
+    // c = a * b;
+
+    // REQUIRE( grad(c, a) == approx(b) );
+
+    //------------------------------------------------------------------------------
     // TEST BINARY ARITHMETIC OPERATORS
     //------------------------------------------------------------------------------
+    a = 100.0;
+    b = 200.0;
+
     c = a + b;
 
     REQUIRE( grad(c, a) == 1.0 );

--- a/test/reverse.test.cpp
+++ b/test/reverse.test.cpp
@@ -143,20 +143,20 @@ TEST_CASE("autodiff::var tests", "[var]")
 
     REQUIRE( grad(c, a) == approx(b + a * grad(b, a)) );
 
-    // a -= 3*b;
-    // c = a * b;
+    a -= 3*b;
+    c = a * b;
 
-    // REQUIRE( grad(c, a) == approx(b) );
+    REQUIRE( grad(c, a) == approx(b) );
 
-    // a *= b;
-    // c = a * b;
+    a *= b;
+    c = a * b;
 
-    // REQUIRE( grad(c, a) == approx(b) );
+    REQUIRE( grad(c, a) == approx(b) );
 
-    // a /= b;
-    // c = a * b;
+    a /= b;
+    c = a * b;
 
-    // REQUIRE( grad(c, a) == approx(b) );
+    REQUIRE( grad(c, a) == approx(b) );
 
     //------------------------------------------------------------------------------
     // TEST BINARY ARITHMETIC OPERATORS


### PR DESCRIPTION
This PR fixes issue #17. It was detected that the problem was due to operators `+=, -=, *=, /=` in `Variable` type not properly dealing with temporaries.