### PR TITLE
Add atan2

### DIFF
--- a/test/forward.test.cpp
+++ b/test/forward.test.cpp
@@ -619,6 +619,32 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         x = -1.4;
         REQUIRE( f(x) == std::erf(val(x)) );
         REQUIRE( derivative(f, wrt(x), at(x)) == approx(0.158942) );
+
+        // Testing atan2 function on (double, dual)
+        f = [](dual x) -> dual { return atan2(2.0, x); };
+        x = 1.0;
+        REQUIRE( f(x) == std::atan2(2.0, val(x)) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(-2.0 / (2*2 + x*x)) );
+
+        // Testing atan2 function on (dual, double)
+        f = [](dual y) -> dual { return atan2(y, 2.0); };
+        x = 1.0;
+        REQUIRE( f(x) == std::atan2(val(x), 2.0) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(2.0 /  (2*2 + x*x)) );
+
+        // Testing atan2 function on (dual, dual)
+        std::function<dual(dual, dual)> g = [](dual y, dual x) -> dual { return atan2(y, x); };
+        x = 1.1;
+        dual y = 0.9;
+        REQUIRE( g(y, x) == std::atan2(val(y), val(x)) );
+        REQUIRE( derivative(g, wrt(y), at(y, x)) == approx(x / (x*x + y*y)) );
+        REQUIRE( derivative(g, wrt(x), at(y, x)) == approx(-y / (x*x + y*y)) );
+
+        // Testing atan2 function on (expr, expr)
+        g = [](dual y, dual x) -> dual { return 3 * atan2(sin(y), 2*x+1); };
+        REQUIRE( g(y, x) == 3 * std::atan2(sin(val(y)), 2*val(x)+1) );
+        REQUIRE( derivative(g, wrt(y), at(y, x)) == approx(3*(2*x+1)*cos(y) / ((2*x+1)*(2*x+1) + sin(y)*sin(y))) );
+        REQUIRE( derivative(g, wrt(x), at(y, x)) == approx(3*-2*sin(y) / ((2*x+1)*(2*x+1) + sin(y)*sin(y))) );
     }
 
     SECTION("testing complex expressions")

--- a/test/reverse.test.cpp
+++ b/test/reverse.test.cpp
@@ -298,6 +298,34 @@ TEST_CASE("autodiff::var tests", "[var]")
     REQUIRE( grad(pow(x, y), a) == Approx( std::pow(val(x), val(y)) * (val(y)/val(x) * grad(x, a) + std::log(val(x)) * grad(y, a)) ) );
     REQUIRE( grad(pow(x, y), y) == Approx( std::log(val(x)) * std::pow(val(x), val(y)) ) );
 
+
+    //--------------------------------------------------------------------------
+    // TEST ATAN2 FUNCTION
+    //--------------------------------------------------------------------------
+
+    // Testing atan2 function on (double, var)
+    x = 1.0;
+    REQUIRE( atan2(2.0, x) == std::atan2(2.0, val(x)) );
+    REQUIRE( grad(atan2(2.0, x), x) == approx(-2.0 / (2*2 + x*x)) );
+
+    // Testing atan2 function on (var, double)
+    x = 1.0;
+    REQUIRE( atan2(x, 2.0) == std::atan2(val(x), 2.0) );
+    REQUIRE( grad(atan2(x, 2.0), x) == approx(2.0 / (2*2 + x*x)) );
+
+    // Testing atan2 function on (var, var)
+    x = 1.1;
+    y = 0.9;
+    REQUIRE( atan2(y, x) == std::atan2(val(y), val(x)) );
+    REQUIRE( grad(atan2(y, x), y) == approx(x / (x*x + y*y)) );
+    REQUIRE( grad(atan2(y, x), x) == approx(-y / (x*x + y*y)) );
+
+    // Testing atan2 function on (expr, expr)
+    REQUIRE( 3*atan2(sin(y), 2 * x + 1) == 3 * std::atan2(sin(val(y)), 2*val(x)+1) );
+    REQUIRE( grad(3*atan2(sin(y), 2 * x + 1), y) == approx(3*(2*x+1)*cos(y) / ((2*x+1)*(2*x+1) + sin(y)*sin(y))) );
+    REQUIRE( grad(3*atan2(sin(y), 2 * x + 1), x) == approx(3*-2*sin(y) / ((2*x+1)*(2*x+1) + sin(y)*sin(y))) );
+
+
     //--------------------------------------------------------------------------
     // TEST OTHER FUNCTIONS
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Really enjoy this library, thanks for building it.

I needed ```atan2``` to use ```autodiff``` together with [```Sophus```](https://github.com/strasdat/Sophus) for gradient-based optimization on Lie Groups. I thought it might be a good idea to add it by default.

The forward version is a bit verbose but could be shortened at the cost of more memory allocation. It seemed to me like this way was more in line with the rest of the library, but since ```atan2``` is relatively obscure compared to other binary operations it could make sense to prioritize code simplicity.