### PR TITLE
resolve some warnings (-Wextra, -Wshadow, -Wnon-virtual-dtor)

### DIFF
--- a/autodiff/common/meta.hpp
+++ b/autodiff/common/meta.hpp
@@ -77,7 +77,7 @@ template<size_t i>
 struct Index
 {
     constexpr static size_t index = i;
-    constexpr operator const size_t() const { return index; }
+    constexpr operator size_t() const { return index; }
     constexpr operator size_t() { return index; }
 };
 

--- a/autodiff/forward/eigen.hpp
+++ b/autodiff/forward/eigen.hpp
@@ -159,7 +159,7 @@ auto count(Tuple&& t) -> std::size_t
 template<typename T>
 struct EigenVectorAdaptor {
     /// implicit construct from value
-    constexpr EigenVectorAdaptor(T val) : val(val) { }
+    constexpr EigenVectorAdaptor(T v) : val(v) { }
     /// operator [] to add array like access
     T operator[](Eigen::Index) const {
         return val;

--- a/autodiff/forward/forward.hpp
+++ b/autodiff/forward/forward.hpp
@@ -541,8 +541,8 @@ struct Dual
     explicit operator T() const { return this->val; }
 
     template<typename U, enableif<isConvertible<U, T> && !isExpr<U>>...>
-    Dual(U&& val)
-    : val(std::forward<U>(val)), grad(0)
+    Dual(U&& v)
+    : val(std::forward<U>(v)), grad(0)
     {
     }
 

--- a/autodiff/reverse/reverse.hpp
+++ b/autodiff/reverse/reverse.hpp
@@ -243,12 +243,15 @@ template<typename T, typename U, EnableIf<isArithmetic<U>>...> bool operator>(co
 /// The abstract type of any node type in the expression tree.
 template<typename T>
 struct Expr
-{
+{    
     /// The value of this expression node.
     T val = {};
 
     /// Construct an Expr object with given value.
-    explicit Expr(const T& val) : val(val) {}
+    explicit Expr(const T& v) : val(v) {}
+    
+    /// Destructor (to avoid warning)
+    virtual ~Expr() {}
 
     /// Update the contribution of this expression in the derivative of the root node of the expression tree.
     /// @param wprime The derivative of the root expression node w.r.t. the child expression of this expression node.
@@ -270,7 +273,7 @@ struct VariableExpr : Expr<T>
     ExprPtr<T> gradx = {};
 
     /// Construct a VariableExpr object with given value.
-    VariableExpr(const T& val) : Expr<T>(val) {}
+    VariableExpr(const T& v) : Expr<T>(v) {}
 };
 
 /// The node in the expression tree representing an independent variable.
@@ -282,7 +285,7 @@ struct IndependentVariableExpr : VariableExpr<T>
     using VariableExpr<T>::gradx;
 
     /// Construct an IndependentVariableExpr object with given value.
-    IndependentVariableExpr(const T& val) : VariableExpr<T>(val)
+    IndependentVariableExpr(const T& v) : VariableExpr<T>(v)
     {
         gradx = constant<T>(0.0); // TODO: Check if this can be done at the seed function.
     }
@@ -310,7 +313,7 @@ struct DependentVariableExpr : VariableExpr<T>
     ExprPtr<T> expr;
 
     /// Construct an DependentVariableExpr object with given value.
-    DependentVariableExpr(const ExprPtr<T>& expr) : VariableExpr<T>(expr->val), expr(expr)
+    DependentVariableExpr(const ExprPtr<T>& e) : VariableExpr<T>(e->val), expr(e)
     {
         gradx = constant<T>(0.0); // TODO: Check if this can be done at the seed function.
     }
@@ -333,10 +336,10 @@ struct ConstantExpr : Expr<T>
 {
     using Expr<T>::Expr;
 
-    virtual void propagate(const T& wprime)
+    virtual void propagate([[maybe_unused]] const T& wprime)
     {}
 
-    virtual void propagatex(const ExprPtr<T>& wprime)
+    virtual void propagatex([[maybe_unused]] const ExprPtr<T>& wprime)
     {}
 };
 
@@ -345,7 +348,7 @@ struct UnaryExpr : Expr<T>
 {
     ExprPtr<T> x;
 
-    UnaryExpr(const T& val, const ExprPtr<T>& x) : Expr<T>(val), x(x) {}
+    UnaryExpr(const T& v, const ExprPtr<T>& e) : Expr<T>(v), x(e) {}
 };
 
 template<typename T>
@@ -372,7 +375,7 @@ struct BinaryExpr : Expr<T>
 {
     ExprPtr<T> l, r;
 
-    BinaryExpr(const T& val, const ExprPtr<T>& l, const ExprPtr<T>& r) : Expr<T>(val), l(l), r(r) {}
+    BinaryExpr(const T& v, const ExprPtr<T>& ll, const ExprPtr<T>& rr) : Expr<T>(v), l(ll), r(rr) {}
 };
 
 template<typename T>
@@ -380,7 +383,7 @@ struct TernaryExpr : Expr<T>
 {
     ExprPtr<T> l, c, r;
     
-    TernaryExpr(const T& val, const ExprPtr<T>& l, const ExprPtr<T>& c, const ExprPtr<T>& r) : Expr<T>(val), l(l), c(c), r(r) {}
+    TernaryExpr(const T& v, const ExprPtr<T>& ll, const ExprPtr<T>& cc, const ExprPtr<T>& rr) : Expr<T>(v), l(ll), c(cc), r(rr) {}
 };
 
 template<typename T>
@@ -478,7 +481,7 @@ struct SinExpr : UnaryExpr<T>
     // Using declarations for data members of base class
     using UnaryExpr<T>::x;
 
-    SinExpr(const T& val, const ExprPtr<T>& x) : UnaryExpr<T>(val, x) {}
+    SinExpr(const T& v, const ExprPtr<T>& e) : UnaryExpr<T>(v, e) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -497,7 +500,7 @@ struct CosExpr : UnaryExpr<T>
     // Using declarations for data members of base class
     using UnaryExpr<T>::x;
 
-    CosExpr(const T& val, const ExprPtr<T>& x) : UnaryExpr<T>(val, x) {}
+    CosExpr(const T& v, const ExprPtr<T>& e) : UnaryExpr<T>(v, e) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -516,7 +519,7 @@ struct TanExpr : UnaryExpr<T>
     // Using declarations for data members of base class
     using UnaryExpr<T>::x;
 
-    TanExpr(const T& val, const ExprPtr<T>& x) : UnaryExpr<T>(val, x) {}
+    TanExpr(const T& v, const ExprPtr<T>& e) : UnaryExpr<T>(v, e) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -537,7 +540,7 @@ struct SinhExpr : UnaryExpr<T>
     // Using declarations for data members of base class
     using UnaryExpr<T>::x;
 
-    SinhExpr(const T& val, const ExprPtr<T>& x) : UnaryExpr<T>(val, x) {}
+    SinhExpr(const T& v, const ExprPtr<T>& e) : UnaryExpr<T>(v, e) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -556,7 +559,7 @@ struct CoshExpr : UnaryExpr<T>
     // Using declarations for data members of base class
     using UnaryExpr<T>::x;
 
-    CoshExpr(const T& val, const ExprPtr<T>& x) : UnaryExpr<T>(val, x) {}
+    CoshExpr(const T& v, const ExprPtr<T>& e) : UnaryExpr<T>(v, e) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -575,7 +578,7 @@ struct TanhExpr : UnaryExpr<T>
     // Using declarations for data members of base class
     using UnaryExpr<T>::x;
 
-    TanhExpr(const T& val, const ExprPtr<T>& x) : UnaryExpr<T>(val, x) {}
+    TanhExpr(const T& v, const ExprPtr<T>& e) : UnaryExpr<T>(v, e) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -596,7 +599,7 @@ struct ArcSinExpr : UnaryExpr<T>
     // Using declarations for data members of base class
     using UnaryExpr<T>::x;
 
-    ArcSinExpr(const T& val, const ExprPtr<T>& x) : UnaryExpr<T>(val, x) {}
+    ArcSinExpr(const T& v, const ExprPtr<T>& e) : UnaryExpr<T>(v, e) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -615,7 +618,7 @@ struct ArcCosExpr : UnaryExpr<T>
     // Using declarations for data members of base class
     using UnaryExpr<T>::x;
 
-    ArcCosExpr(const T& val, const ExprPtr<T>& x) : UnaryExpr<T>(val, x) {}
+    ArcCosExpr(const T& v, const ExprPtr<T>& e) : UnaryExpr<T>(v, e) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -634,7 +637,7 @@ struct ArcTanExpr : UnaryExpr<T>
     // Using declarations for data members of base class
     using UnaryExpr<T>::x;
 
-    ArcTanExpr(const T& val, const ExprPtr<T>& x) : UnaryExpr<T>(val, x) {}
+    ArcTanExpr(const T& v, const ExprPtr<T>& e) : UnaryExpr<T>(v, e) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -654,7 +657,7 @@ struct ArcTan2Expr : BinaryExpr<T>
     using BinaryExpr<T>::l;
     using BinaryExpr<T>::r;
 
-    ArcTan2Expr(const T& val, const ExprPtr<T>& l, const ExprPtr<T>& r) : BinaryExpr<T>(val, l, r) {}
+    ArcTan2Expr(const T& v, const ExprPtr<T>& ll, const ExprPtr<T>& rr) : BinaryExpr<T>(v, ll, rr) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -716,7 +719,7 @@ struct Log10Expr : UnaryExpr<T>
 
     constexpr static auto ln10 = static_cast<VariableValueType<T>>(2.3025850929940456840179914546843);
 
-    Log10Expr(const T& val, const ExprPtr<T>& x) : UnaryExpr<T>(val, x) {}
+    Log10Expr(const T& v, const ExprPtr<T>& e) : UnaryExpr<T>(v, e) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -739,7 +742,7 @@ struct PowExpr : BinaryExpr<T>
 
     T log_l;
 
-    PowExpr(const T& val, const ExprPtr<T>& l, const ExprPtr<T>& r) : BinaryExpr<T>(val, l, r), log_l(log(l->val)) {}
+    PowExpr(const T& v, const ExprPtr<T>& ll, const ExprPtr<T>& rr) : BinaryExpr<T>(v, ll, rr), log_l(log(ll->val)) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -766,7 +769,7 @@ struct PowConstantLeftExpr : BinaryExpr<T>
     using BinaryExpr<T>::l;
     using BinaryExpr<T>::r;
 
-    PowConstantLeftExpr(const T& val, const ExprPtr<T>& l, const ExprPtr<T>& r) : BinaryExpr<T>(val, l, r) {}
+    PowConstantLeftExpr(const T& v, const ExprPtr<T>& ll, const ExprPtr<T>& rr) : BinaryExpr<T>(v, ll, rr) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -787,7 +790,7 @@ struct PowConstantRightExpr : BinaryExpr<T>
     using BinaryExpr<T>::l;
     using BinaryExpr<T>::r;
 
-    PowConstantRightExpr(const T& val, const ExprPtr<T>& l, const ExprPtr<T>& r) : BinaryExpr<T>(val, l, r) {}
+    PowConstantRightExpr(const T& v, const ExprPtr<T>& ll, const ExprPtr<T>& rr) : BinaryExpr<T>(v, ll, rr) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -806,7 +809,7 @@ struct SqrtExpr : UnaryExpr<T>
     // Using declarations for data members of base class
     using UnaryExpr<T>::x;
 
-    SqrtExpr(const T& val, const ExprPtr<T>& x) : UnaryExpr<T>(val, x) {}
+    SqrtExpr(const T& v, const ExprPtr<T>& e) : UnaryExpr<T>(v, e) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -826,7 +829,7 @@ struct AbsExpr : UnaryExpr<T>
     using UnaryExpr<T>::x;
     using U = VariableValueType<T>;
 
-    AbsExpr(const T& val, const ExprPtr<T>& x) : UnaryExpr<T>(val, x) {}
+    AbsExpr(const T& v, const ExprPtr<T>& e) : UnaryExpr<T>(v, e) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -849,7 +852,7 @@ struct ErfExpr : UnaryExpr<T>
 
     constexpr static auto sqrt_pi = static_cast<VariableValueType<T>>(1.7724538509055160272981674833411451872554456638435);
 
-    ErfExpr(const T& val, const ExprPtr<T>& x) : UnaryExpr<T>(val, x) {}
+    ErfExpr(const T& v, const ExprPtr<T>& e) : UnaryExpr<T>(v, e) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -872,7 +875,7 @@ struct Hypot2Expr : BinaryExpr<T>
     using BinaryExpr<T>::l;
     using BinaryExpr<T>::r;
 
-    Hypot2Expr(const T& val, const ExprPtr<T>& l, const ExprPtr<T>& r) : BinaryExpr<T>(val, l, r) {}
+    Hypot2Expr(const T& v, const ExprPtr<T>& ll, const ExprPtr<T>& rr) : BinaryExpr<T>(v, ll, rr) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -896,7 +899,7 @@ struct Hypot3Expr : TernaryExpr<T>
     using TernaryExpr<T>::c;
     using TernaryExpr<T>::r;
     
-    Hypot3Expr(const T& val, const ExprPtr<T>& l, const ExprPtr<T>& c, const ExprPtr<T>& r) : TernaryExpr<T>(val, l, c, r) {}
+    Hypot3Expr(const T& v, const ExprPtr<T>& ll, const ExprPtr<T>& cc, const ExprPtr<T>& rr) : TernaryExpr<T>(v, ll, cc, rr) {}
 
     virtual void propagate(const T& wprime)
     {
@@ -1046,7 +1049,10 @@ struct Variable
     Variable(const U& val) : expr(std::make_shared<IndependentVariableExpr<T>>(val)) {}
 
     /// Construct a Variable object with given expression
-    Variable(const ExprPtr<T>& expr) : expr(std::make_shared<DependentVariableExpr<T>>(expr)) {}
+    Variable(const ExprPtr<T>& e) : expr(std::make_shared<DependentVariableExpr<T>>(e)) {}
+    
+    /// Default copy assignment
+    Variable &operator=(const Variable &) = default;
 
     /// Return a pointer to the underlying VariableExpr object in this variable.
     auto __variableExpr() const { return static_cast<VariableExpr<T>*>(expr.get()); }


### PR DESCRIPTION
Hi,

this is not actually very important, but at least for the project I'm working on these warnings trigger, so I decided to resolve them. Maybe there is also some benefit for other people... 
There shouldn't be any change in functionality, just some variable renaming and additional default constructors/destructors...). I also did not resolve the warnings in the tests. The only warnings I still get are related to Eigen.