### PR TITLE
Integrate bazel.build 

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --cxxopt='-std=c++17'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,8 +37,8 @@ jobs:
       shell: powershell
       run: |
         conda activate autodiff
-        cmake -S . -B build
-        cmake --build build --config ${{ env.configuration }} --target install
+        cmake -S . -B .build
+        cmake --build .build --config ${{ env.configuration }} --target install
     - name: Tests
       shell: powershell
-      run: .\build\test\${{ env.configuration }}\tests.exe
+      run: .\.build\test\${{ env.configuration }}\tests.exe

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ language.settings.xml
 
 # Qt Creator files
 CMakeLists.txt.user
+
+# Bazel
+/bazel-**

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,7 @@
+cc_library(
+    name = "autodiff",
+    deps = ["//autodiff:reverse",
+            "//autodiff:forward"],
+    visibility = ["//visibility:public"],
+    copts = ["-I./"]
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,8 @@
 workspace(name = "autodiff")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+
 
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,20 @@
+workspace(name = "autodiff")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+
+http_archive(
+    name = "com_github_eigen_eigen",
+    build_file_content = """
+cc_library(
+    name = 'eigen',
+    srcs = [],
+    includes = ['.'],
+    hdrs = glob(['Eigen/**']),
+    visibility = ['//visibility:public'],
+)
+""",
+    sha256 = "4b1120abc5d4a63620a886dcc5d7a7a27bf5b048c8c74ac57521dd27845b1d9f",
+    strip_prefix = "eigen-git-mirror-98e54de5e25aefc6b984c168fb3009868a93e217",
+    urls = ["https://github.com/eigenteam/eigen-git-mirror/archive/98e54de5e25aefc6b984c168fb3009868a93e217.zip"]
+)

--- a/autodiff/BUILD
+++ b/autodiff/BUILD
@@ -1,0 +1,21 @@
+cc_library(
+    name = "common",
+    hdrs = glob(["common/eigen.hpp", "common/meta.hpp"]),
+    deps = ["@com_github_eigen_eigen//:eigen"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "reverse",
+    hdrs = glob(["reverse.hpp", "reverse/*.hpp"]),
+    deps = ["@com_github_eigen_eigen//:eigen",
+            ":common"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "forward",
+    hdrs = glob(["forward.hpp", "forward/*.hpp"]),
+    deps = ["@com_github_eigen_eigen//:eigen"],
+    visibility = ["//visibility:public"],
+)

--- a/ci/actions/install.sh
+++ b/ci/actions/install.sh
@@ -7,7 +7,7 @@ conda update -q conda
 conda info -a
 conda devenv
 source activate autodiff
-mkdir build
-cd build || exit
+mkdir .build
+cd .build || exit
 cmake .. -GNinja
 ninja

--- a/ci/actions/test.sh
+++ b/ci/actions/test.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-./build/test/tests
+./.build/test/tests

--- a/examples/forward/BUILD
+++ b/examples/forward/BUILD
@@ -1,0 +1,100 @@
+cc_test(
+    name = "example-forward-single-variable-function",
+    srcs=["example-forward-single-variable-function.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-forward-single-variable-function-custom-scalar",
+    srcs = ["example-forward-single-variable-function-custom-scalar.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-forward-multi-variable-function",
+    srcs=["example-forward-multi-variable-function.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-forward-multi-variable-function-with-parameters",
+    srcs = ["example-forward-multi-variable-function-with-parameters.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-forward-jacobian-derivatives-using-eigen",
+    srcs = ["example-forward-jacobian-derivatives-using-eigen.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-forward-jacobian-derivatives-using-eigen-with-scalar",
+    srcs = ["example-forward-jacobian-derivatives-using-eigen-with-scalar.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-forward-jacobian-derivatives-using-eigen-with-parameters",
+    srcs = ["example-forward-jacobian-derivatives-using-eigen-with-parameters.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-forward-higher-order-derivatives",
+    srcs = ["example-forward-higher-order-derivatives.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-forward-hessian-derivatives-using-eigen",
+    srcs = ["example-forward-hessian-derivatives-using-eigen.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-forward-hessian-derivatives-using-eigen-with-scalar",
+    srcs = ["example-forward-hessian-derivatives-using-eigen-with-scalar.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-forward-hessian-derivatives-using-eigen-with-parameters",
+    srcs = ["example-forward-hessian-derivatives-using-eigen-with-parameters.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-forward-gradient-derivatives-using-eigen",
+    srcs = ["example-forward-gradient-derivatives-using-eigen.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-forward-gradient-derivatives-using-eigen-with-scalar",
+    srcs = ["example-forward-gradient-derivatives-using-eigen-with-scalar.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-forward-gradient-derivatives-using-eigen-with-parameters",
+    srcs = ["example-forward-gradient-derivatives-using-eigen-with-parameters.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+
+

--- a/examples/reverse/BUILD
+++ b/examples/reverse/BUILD
@@ -1,0 +1,48 @@
+cc_test(
+    name = "example-reverse-gradient-derivatives-using-eigen",
+    srcs=["example-reverse-gradient-derivatives-using-eigen.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-reverse-hessian-derivatives-using-eigen",
+    srcs = ["example-reverse-hessian-derivatives-using-eigen.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-reverse-higher-order-derivatives-multi-variable-function",
+    srcs=["example-reverse-higher-order-derivatives-multi-variable-function.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-reverse-higher-order-derivatives-single-variable-function",
+    srcs = ["example-reverse-higher-order-derivatives-single-variable-function.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-reverse-multi-variable-function-with-parameters",
+    srcs = ["example-reverse-multi-variable-function-with-parameters.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-reverse-multi-variable-function",
+    srcs = ["example-reverse-multi-variable-function.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)
+
+cc_test(
+    name = "example-reverse-single-variable-function",
+    srcs = ["example-reverse-single-variable-function.cpp"],
+    deps = ["//:autodiff"],
+    copts = ["-I./"]
+)

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,0 +1,18 @@
+cc_test(
+    name = "forward",
+    srcs = ["catch.hpp", "forward.test.cpp"],
+    deps = [
+        "//:autodiff",
+    ],
+    copts = ["-I./"],
+    defines = ["CATCH_CONFIG_MAIN"]
+)
+
+cc_test(
+    name = "reverse",
+    srcs = ["catch.hpp", "reverse.test.cpp"],
+    deps = [
+        "//:autodiff",
+    ],
+    copts = ["-I./"]
+)


### PR DESCRIPTION
# Description
This PR introduces [bazel.build](https://bazel.build/) for the usage within bazel projects

# Type of change
- Bazel WORKSPACE file
- Bazel BUILD files
- Integration of examples as cc_test

# Benefits
- Could enable a better CI testing
- People can use autodiff in their Bazel projects easily