### PR TITLE
Return zero sub-gradient for abs(x) at x=0

### DIFF
--- a/autodiff/forward/forward.hpp
+++ b/autodiff/forward/forward.hpp
@@ -1744,9 +1744,8 @@ constexpr void apply(Dual<T, G>& self, SqrtOp)
 template<typename T, typename G>
 constexpr void apply(Dual<T, G>& self, AbsOp)
 {
-    const T aux = self.val;
+    self.grad *= self.val < T(0) ? G(-1) : (self.val > T(0) ? G(1) : G(0));
     self.val = abs(self.val);
-    self.grad *= aux / self.val;
 }
 
 template<typename T, typename G>

--- a/autodiff/reverse/reverse.hpp
+++ b/autodiff/reverse/reverse.hpp
@@ -834,13 +834,15 @@ struct AbsExpr : UnaryExpr<T>
     virtual void propagate(const T& wprime)
     {
         if(x->val < 0.0) x->propagate(-wprime);
-        else x->propagate(wprime);
+        else if (x->val > 0.0) x->propagate(wprime);
+        else x->propagate(T(0));
     }
 
     virtual void propagatex(const ExprPtr<T>& wprime)
     {
         if(x->val < 0.0) x->propagatex(-wprime);
-        else x->propagatex(wprime);
+        else if (x->val > 0.0) x->propagatex(wprime);
+        else x->propagate(T(0));
     }
 };
 

--- a/test/forward.test.cpp
+++ b/test/forward.test.cpp
@@ -602,7 +602,7 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         REQUIRE( f(x) == std::pow(val(x), 2.0 * val(x)) );
         REQUIRE( derivative(f, wrt(x), at(x)) == approx(2.0 * (log(x) + 1) * pow(x, 2.0 * x)) );
 
-        // Testing abs function (when x > 0 and when x < 0)
+        // Testing abs function (for x > 0, x < 0, and x = 0)
         f = [](dual x) -> dual { return abs(x); };
         x = 1.0;
         REQUIRE( f(x) == std::abs(val(x)) );
@@ -610,6 +610,10 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         x = -1.0;
         REQUIRE( f(x) == std::abs(val(x)) );
         REQUIRE( derivative(f, wrt(x), at(x)) == approx(-1.0) );
+        x = 0;
+        REQUIRE( f(x) == std::abs(val(x)) );
+        REQUIRE( derivative(f, wrt(x), at(x)) == approx(0.0) );
+
 
         // Testing erf function
         f = [](dual x) -> dual { return erf(x); };

--- a/test/reverse.test.cpp
+++ b/test/reverse.test.cpp
@@ -300,6 +300,21 @@ TEST_CASE("autodiff::var tests", "[var]")
 
 
     //--------------------------------------------------------------------------
+    // TEST ABS FUNCTION
+    //--------------------------------------------------------------------------
+
+    x = 1.0;
+    REQUIRE( val(abs(x)) == std::abs(val(x)) );
+    REQUIRE( grad(abs(x), x) == approx(1.0) );
+    x = -1.0;
+    REQUIRE( val(abs(x)) == std::abs(val(x)) );
+    REQUIRE( grad(abs(x), x) == approx(-1.0) );
+    x = 0.0;
+    REQUIRE( val(abs(x)) == std::abs(val(x)) );
+    REQUIRE( grad(abs(x), x) == approx(0.0) );
+
+
+    //--------------------------------------------------------------------------
     // TEST ATAN2 FUNCTION
     //--------------------------------------------------------------------------
 


### PR DESCRIPTION
Perhaps a minor issue, but there is currently a discrepancy between the reverse and forward modes for ```abs(x)``` at ```x=0```, where reverse mode returns derivative ```+1``` and forward results in a NaN after division by zero. Though the regular derivative is undefined at ```x=0``` it seems better to compute one of the sub-derivatives in ```[-1, 1]``` instead of dividing by zero.

I chose 0 here which seemed nice and symmetric and is what e.g. ```pytorch``` does.