### PR TITLE
Update setup-miniconda GH action version

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: goanpeca/setup-miniconda@v1.0.2
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
     - name: Install

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
 
-    runs-on: [macOS-latest]
+    runs-on: macOS-latest
     env:
       os: MacOSX-x86_64
     strategy:
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: goanpeca/setup-miniconda@v1.0.2
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
     - name: Install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: conda-incubator/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
         auto-activate-base: true


### PR DESCRIPTION
GH Actions had an update in October that require us to update `setup-miniconda` in `autodiff` CI. The `setup-miniconda` needs to be bumped to `v2` for all builds.

I'm updating it because one day the CI build would break.