### PR TITLE
resolving -Wunused-parameter warnings for clang

### DIFF
--- a/autodiff/common/meta.hpp
+++ b/autodiff/common/meta.hpp
@@ -67,7 +67,7 @@ constexpr auto TupleHead(Tuple&& tuple)
 template<typename Tuple>
 constexpr auto TupleTail(Tuple&& tuple)
 {
-    auto g = [&](auto&& arg, auto&&... args) constexpr {
+    auto g = [&](auto&&, auto&&... args) constexpr {
         return std::forward_as_tuple(args...);
     };
     return std::apply(g, std::forward<Tuple>(tuple));

--- a/autodiff/forward/forward.hpp
+++ b/autodiff/forward/forward.hpp
@@ -1016,7 +1016,7 @@ template<typename R, enableif<isExpr<R>>...> constexpr auto abs(R&& r) -> AbsExp
 template<typename R, enableif<isExpr<R>>...> constexpr auto abs2(R&& r) { return std::forward<R>(r) * std::forward<R>(r); }
 template<typename R, enableif<isExpr<R>>...> constexpr auto conj(R&& r) { return std::forward<R>(r); }
 template<typename R, enableif<isExpr<R>>...> constexpr auto real(R&& r) { return std::forward<R>(r); }
-template<typename R, enableif<isExpr<R>>...> constexpr auto imag(R&& r) { return 0.0; }
+template<typename R, enableif<isExpr<R>>...> constexpr auto imag(R&&) { return 0.0; }
 template<typename R, enableif<isExpr<R>>...> constexpr auto erf(R&& r) -> ErfExpr<R> { return { r }; }
 
 //=====================================================================================================================

--- a/autodiff/reverse/reverse.hpp
+++ b/autodiff/reverse/reverse.hpp
@@ -1006,7 +1006,7 @@ template<typename T> ExprPtr<T> abs(const ExprPtr<T>& x) { return std::make_shar
 template<typename T> ExprPtr<T> abs2(const ExprPtr<T>& x) { return x * x; }
 template<typename T> ExprPtr<T> conj(const ExprPtr<T>& x) { return x; }
 template<typename T> ExprPtr<T> real(const ExprPtr<T>& x) { return x; }
-template<typename T> ExprPtr<T> imag(const ExprPtr<T>& x) { return constant<T>(0.0); }
+template<typename T> ExprPtr<T> imag(const ExprPtr<T>&) { return constant<T>(0.0); }
 template<typename T> ExprPtr<T> erf(const ExprPtr<T>& x) { return std::make_shared<ErfExpr<T>>(erf(x->val), x); }
 
 //------------------------------------------------------------------------------
@@ -1239,7 +1239,7 @@ auto val(const ExprPtr<T>& x)
 /// Return the derivatives of a variable y with respect to all independent variables.
 template<typename T>
 [[deprecated("Use method `derivatives(y, wrt(a, b, c,...)` instead.")]]
-auto derivatives(const T& y)
+auto derivatives(const T&)
 {
     static_assert(!std::is_same_v<T,T>, "Method derivatives(const var&) has been deprecated. Use method derivatives(y, wrt(a, b, c,...) instead.");
 }
@@ -1247,7 +1247,7 @@ auto derivatives(const T& y)
 /// Return the derivatives of a variable y with respect to all independent variables.
 template<typename T>
 [[deprecated("Use method derivativesx(y, wrt(a, b, c,...) instead.")]]
-auto derivativesx(const T& y)
+auto derivativesx(const T&)
 {
     static_assert(!std::is_same_v<T,T>, "Method derivativesx(const var&) has been deprecated. Use method derivativesx(y, wrt(a, b, c,...) instead.");
 }


### PR DESCRIPTION
This PR does resolves some warnings triggered by `-Wunused-parameter` on clang. It would be great if this could be merged in, since this triggers the MacOS CI configuration in a project where I want to use `autodiff`.