### PR TITLE
Implement missing comparison operators between Variable and ExprPtr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(CCache)
 
 # Name and details of the project
-project(autodiff VERSION 0.5.11 LANGUAGES CXX)
+project(autodiff VERSION 0.5.13 LANGUAGES CXX)
 
 # Include the cmake variables with values for installation directories
 include(GNUInstallDirs)

--- a/autodiff/reverse/reverse.hpp
+++ b/autodiff/reverse/reverse.hpp
@@ -1085,16 +1085,16 @@ struct Variable
     auto operator=(const ExprPtr<T>& x) -> Variable& { *this = Variable(x); return *this; }
 
 	// Assignment operators
-    Variable& operator+=(const ExprPtr<T>& x) { expr = expr + x; return *this; }
-    Variable& operator-=(const ExprPtr<T>& x) { expr = expr - x; return *this; }
-    Variable& operator*=(const ExprPtr<T>& x) { expr = expr * x; return *this; }
-    Variable& operator/=(const ExprPtr<T>& x) { expr = expr / x; return *this; }
+    Variable& operator+=(const ExprPtr<T>& x) { *this = Variable(expr + x); return *this; }
+    Variable& operator-=(const ExprPtr<T>& x) { *this = Variable(expr - x); return *this; }
+    Variable& operator*=(const ExprPtr<T>& x) { *this = Variable(expr * x); return *this; }
+    Variable& operator/=(const ExprPtr<T>& x) { *this = Variable(expr / x); return *this; }
 
 	// Assignment operators with arithmetic values
-    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator+=(const U& x) { expr = expr + x; return *this; }
-    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator-=(const U& x) { expr = expr - x; return *this; }
-    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator*=(const U& x) { expr = expr * x; return *this; }
-    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator/=(const U& x) { expr = expr / x; return *this; }
+    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator+=(const U& x) { *this = Variable(expr + x); return *this; }
+    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator-=(const U& x) { *this = Variable(expr - x); return *this; }
+    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator*=(const U& x) { *this = Variable(expr * x); return *this; }
+    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator/=(const U& x) { *this = Variable(expr / x); return *this; }
 };
 
 //------------------------------------------------------------------------------

--- a/autodiff/reverse/reverse.hpp
+++ b/autodiff/reverse/reverse.hpp
@@ -243,13 +243,13 @@ template<typename T, typename U, EnableIf<isArithmetic<U>>...> bool operator>(co
 /// The abstract type of any node type in the expression tree.
 template<typename T>
 struct Expr
-{    
+{
     /// The value of this expression node.
     T val = {};
 
     /// Construct an Expr object with given value.
     explicit Expr(const T& v) : val(v) {}
-    
+
     /// Destructor (to avoid warning)
     virtual ~Expr() {}
 
@@ -382,7 +382,7 @@ template<typename T>
 struct TernaryExpr : Expr<T>
 {
     ExprPtr<T> l, c, r;
-    
+
     TernaryExpr(const T& v, const ExprPtr<T>& ll, const ExprPtr<T>& cc, const ExprPtr<T>& rr) : Expr<T>(v), l(ll), c(cc), r(rr) {}
 };
 
@@ -900,7 +900,7 @@ struct Hypot3Expr : TernaryExpr<T>
     using TernaryExpr<T>::l;
     using TernaryExpr<T>::c;
     using TernaryExpr<T>::r;
-    
+
     Hypot3Expr(const T& v, const ExprPtr<T>& ll, const ExprPtr<T>& cc, const ExprPtr<T>& rr) : TernaryExpr<T>(v, ll, cc, rr) {}
 
     virtual void propagate(const T& wprime)
@@ -1052,7 +1052,7 @@ struct Variable
 
     /// Construct a Variable object with given expression
     Variable(const ExprPtr<T>& e) : expr(std::make_shared<DependentVariableExpr<T>>(e)) {}
-    
+
     /// Default copy assignment
     Variable &operator=(const Variable &) = default;
 
@@ -1085,16 +1085,16 @@ struct Variable
     auto operator=(const ExprPtr<T>& x) -> Variable& { *this = Variable(x); return *this; }
 
 	// Assignment operators
-    Variable& operator+=(const ExprPtr<T>& x) { *this = Variable(expr + x); return *this; }
-    Variable& operator-=(const ExprPtr<T>& x) { *this = Variable(expr - x); return *this; }
-    Variable& operator*=(const ExprPtr<T>& x) { *this = Variable(expr * x); return *this; }
-    Variable& operator/=(const ExprPtr<T>& x) { *this = Variable(expr / x); return *this; }
+    Variable& operator+=(const ExprPtr<T>& x) { expr = expr + x; return *this; }
+    Variable& operator-=(const ExprPtr<T>& x) { expr = expr - x; return *this; }
+    Variable& operator*=(const ExprPtr<T>& x) { expr = expr * x; return *this; }
+    Variable& operator/=(const ExprPtr<T>& x) { expr = expr / x; return *this; }
 
 	// Assignment operators with arithmetic values
-    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator+=(const U& x) { *this = Variable(expr + x); return *this; }
-    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator-=(const U& x) { *this = Variable(expr - x); return *this; }
-    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator*=(const U& x) { *this = Variable(expr * x); return *this; }
-    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator/=(const U& x) { *this = Variable(expr / x); return *this; }
+    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator+=(const U& x) { expr = expr + x; return *this; }
+    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator-=(const U& x) { expr = expr - x; return *this; }
+    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator*=(const U& x) { expr = expr * x; return *this; }
+    template<typename U, EnableIf<isArithmetic<U>>...> Variable& operator/=(const U& x) { expr = expr / x; return *this; }
 };
 
 //------------------------------------------------------------------------------
@@ -1106,6 +1106,20 @@ template<typename T> bool operator<=(const Variable<T>& l, const Variable<T>& r)
 template<typename T> bool operator>=(const Variable<T>& l, const Variable<T>& r) { return l.expr >= r.expr; }
 template<typename T> bool operator<(const Variable<T>& l, const Variable<T>& r) { return l.expr < r.expr; }
 template<typename T> bool operator>(const Variable<T>& l, const Variable<T>& r) { return l.expr > r.expr; }
+
+template<typename T> bool operator==(const Variable<T>& l, const ExprPtr<T>& r) { return l.expr->val == r->val; }
+template<typename T> bool operator!=(const Variable<T>& l, const ExprPtr<T>& r) { return l.expr->val != r->val; }
+template<typename T> bool operator<=(const Variable<T>& l, const ExprPtr<T>& r) { return l.expr->val <= r->val; }
+template<typename T> bool operator>=(const Variable<T>& l, const ExprPtr<T>& r) { return l.expr->val >= r->val; }
+template<typename T> bool operator<(const Variable<T>& l, const ExprPtr<T>& r) { return l.expr->val < r->val; }
+template<typename T> bool operator>(const Variable<T>& l, const ExprPtr<T>& r) { return l.expr->val > r->val; }
+
+template<typename T> bool operator==(const ExprPtr<T>& l, const Variable<T>& r) { return l->val == r.expr->val; }
+template<typename T> bool operator!=(const ExprPtr<T>& l, const Variable<T>& r) { return l->val != r.expr->val; }
+template<typename T> bool operator<=(const ExprPtr<T>& l, const Variable<T>& r) { return l->val <= r.expr->val; }
+template<typename T> bool operator>=(const ExprPtr<T>& l, const Variable<T>& r) { return l->val >= r.expr->val; }
+template<typename T> bool operator<(const ExprPtr<T>& l, const Variable<T>& r) { return l->val < r.expr->val; }
+template<typename T> bool operator>(const ExprPtr<T>& l, const Variable<T>& r) { return l->val > r.expr->val; }
 
 template<typename T, typename U, EnableIf<isArithmetic<U>>...> bool operator==(const U& l, const Variable<T>& r) { return l == r.expr; }
 template<typename T, typename U, EnableIf<isArithmetic<U>>...> bool operator!=(const U& l, const Variable<T>& r) { return l != r.expr; }

--- a/test/reverse.test.cpp
+++ b/test/reverse.test.cpp
@@ -226,6 +226,33 @@ TEST_CASE("autodiff::var tests", "[var]")
     REQUIRE( 10 >= a );
     REQUIRE( 20 >= a );
 
+    //------------------------------------------------------------------------------
+    // TEST COMPARISON OPERATORS BETWEEN VARIABLE AND EXPRPTR
+    //------------------------------------------------------------------------------
+    REQUIRE( a == a/a * a );
+    REQUIRE( a/a * a == a );
+
+    REQUIRE( a != a - a );
+    REQUIRE( a - a != a );
+
+    REQUIRE( a - a < a );
+    REQUIRE( a < a + a );
+
+    REQUIRE( a + a > a );
+    REQUIRE( a > a - a );
+
+    REQUIRE( a <= a - a + a );
+    REQUIRE( a - a + a <= a );
+
+    REQUIRE( a <= a + a );
+    REQUIRE( a - a <= a );
+
+    REQUIRE( a >= a - a + a );
+    REQUIRE( a - a + a >= a );
+
+    REQUIRE( a + a >= a );
+    REQUIRE( a >= a - a );
+
     //--------------------------------------------------------------------------
     // TEST TRIGONOMETRIC FUNCTIONS
     //--------------------------------------------------------------------------
@@ -344,7 +371,7 @@ TEST_CASE("autodiff::var tests", "[var]")
     //--------------------------------------------------------------------------
     // TEST HYPOT2 FUNCTIONS
     //--------------------------------------------------------------------------
-    
+
     // Testing hypot function on (var, double)
     x = 1.8;
     REQUIRE( hypot(x, 2.0) == std::hypot(val(x), 2.0) );
@@ -354,14 +381,14 @@ TEST_CASE("autodiff::var tests", "[var]")
     y = 1.5;
     REQUIRE( hypot(2.0, y) == std::hypot(2.0, val(y)) );
     REQUIRE( grad(hypot(2.0, y), y) == approx(y / std::hypot(2.0, val(y))) );
-    
+
     // Testing hypot function on (var, var)
     x = 1.3;
     y = 2.3;
     REQUIRE( hypot(x, y) == std::hypot(val(x), val(y)) );
     REQUIRE( grad(hypot(x, y), x) == approx(x / std::hypot(val(x), val(y))) );
     REQUIRE( grad(hypot(x, y), y) == approx(y / std::hypot(val(x), val(y))) );
-    
+
     // Testing hypot function on (expr, expr)
     x = 1.3;
     y = 2.3;
@@ -378,38 +405,38 @@ TEST_CASE("autodiff::var tests", "[var]")
     x = 1.5;
     REQUIRE( hypot(x, 2.0, 3.0) == std::hypot(val(x), 2.0, 3.0) );
     REQUIRE( grad(hypot(x, 2.0, 3.0), x) == approx(x / std::hypot(val(x), 2.0, 3.0)) );
-    
+
     // Testing hypot function on (double, var, double)
     y = 1.8;
     REQUIRE( hypot(2.0, y, 3.0) == std::hypot(2.0, val(y), 3.0) );
     REQUIRE( grad(hypot(2.0, y, 3.0), y) == approx(y / std::hypot(2.0, val(y), 3.0)) );
-    
+
     // Testing hypot function on (double, var, double)
     var z = 1.9;
     REQUIRE( hypot(2.0, 3.0, z) == std::hypot(2.0, 3.0, val(z)) );
     REQUIRE( grad(hypot(2.0, 3.0, z), z) == approx(z / std::hypot(2.0, 3.0, val(z))) );
-    
+
     // Testing hypot function on (var, var, double)
     x = 1.3;
     y = 2.3;
     REQUIRE( hypot(x, y, 2.0) == std::hypot(val(x), val(y), 2.0) );
     REQUIRE( grad(hypot(x, y, 2.0), x) == approx(x / std::hypot(val(x), val(y), 2.0)) );
     REQUIRE( grad(hypot(x, y, 2.0), y) == approx(y / std::hypot(val(x), val(y), 2.0)) );
-    
+
     // Testing hypot function on (double, var, var)
     y = 2.3;
     z = 3.3;
     REQUIRE( hypot(2.0, y, z) == std::hypot(2.0, val(y), val(z)) );
     REQUIRE( grad(hypot(2.0, y, z), y) == approx(y / std::hypot(2.0, val(y), val(z))) );
     REQUIRE( grad(hypot(2.0, y, z), z) == approx(z / std::hypot(2.0, val(y), val(z))) );
-    
+
     // Testing hypot function on (double, var, var)
     x = 3.3;
     z = 4.3;
     REQUIRE( hypot(x, 2.0, z) == std::hypot(val(x), 2.0, val(z)) );
     REQUIRE( grad(hypot(x, 2.0, z), x) == approx(x / std::hypot(val(x), 2.0, val(z))) );
     REQUIRE( grad(hypot(x, 2.0, z), z) == approx(z / std::hypot(val(x), 2.0, val(z))) );
-    
+
     // Testing hypot function on (var, var, var)
     x = 4.3;
     y = 5.3;
@@ -418,13 +445,13 @@ TEST_CASE("autodiff::var tests", "[var]")
     REQUIRE( grad(hypot(x, y, z), x) == approx(x / std::hypot(val(x), val(y), val(z))) );
     REQUIRE( grad(hypot(x, y, z), y) == approx(y / std::hypot(val(x), val(y), val(z))) );
     REQUIRE( grad(hypot(x, y, z), z) == approx(z / std::hypot(val(x), val(y), val(z))) );
-    
+
     // Testing hypot function on (expr, expr, expr)
     REQUIRE( hypot(2.0*x, 3.0*y, 4.0*z) == std::hypot(2.0*val(x), 3.0*val(y), 4.0*val(z)) );
     REQUIRE( grad(hypot(2.0*x, 3.0*y, 4.0*z), x) == approx(4.0*x / std::hypot(2.0*val(x), 3.0*val(y), 4.0*val(z))) );
     REQUIRE( grad(hypot(2.0*x, 3.0*y, 4.0*z), y) == approx(9.0*y / std::hypot(2.0*val(x), 3.0*val(y), 4.0*val(z))) );
     REQUIRE( grad(hypot(2.0*x, 3.0*y, 4.0*z), z) == approx(16.*z / std::hypot(2.0*val(x), 3.0*val(y), 4.0*val(z))) );
-    
+
 
     //--------------------------------------------------------------------------
     // TEST OTHER FUNCTIONS


### PR DESCRIPTION
This PR implements missing comparison operators for `reverse::Variable` and `reverse::ExprPtr`. This fixes issue #137 .