### PR TITLE
Fixes for higher order dual numbers

### DIFF
--- a/autodiff/forward/eigen.hpp
+++ b/autodiff/forward/eigen.hpp
@@ -212,7 +212,7 @@ auto gradient(const Function& f, Wrt&& wrt, Args&& args, Result& u) -> Eigen::Ve
             w[j].grad = 1.0;
             u = std::apply(f, args);
             w[j].grad = 0.0;
-            g[j + current_index_pos] = u.grad;
+            g[j + current_index_pos] = val(u.grad);
         }
 
         current_index_pos += w.size();
@@ -247,7 +247,7 @@ auto jacobian(const Function& f, Wrt&& wrt, Args&& args, Result& F) -> Eigen::Ma
     Eigen::MatrixXd J(m, n);
 
     for(auto i = 0; i < m; ++i)
-        J(i, 0) = F[i].grad;
+        J(i, 0) = val(F[i].grad);
 
     Eigen::Index current_index_pos = std::get<0>(wrt).size();
     constexpr auto wrt_count = std::tuple_size_v<std::remove_reference_t<Wrt>>;
@@ -257,7 +257,7 @@ auto jacobian(const Function& f, Wrt&& wrt, Args&& args, Result& F) -> Eigen::Ma
         w[0].grad = 0.0;
 
         for(auto i = 0; i < m; ++i)
-            J(i, current_index_pos) = F[i].grad;
+            J(i, current_index_pos) = val(F[i].grad);
 
         current_index_pos += w.size();
     });
@@ -271,7 +271,7 @@ auto jacobian(const Function& f, Wrt&& wrt, Args&& args, Result& F) -> Eigen::Ma
             w[j].grad = 0.0;
 
             for(auto i = 0; i < m; ++i)
-                J(i, j + current_index_pos) = F[i].grad;
+                J(i, j + current_index_pos) = val(F[i].grad);
         }
 
         current_index_pos += w.size();
@@ -315,8 +315,8 @@ auto hessian(const Function& f, Wrt&& wrt, Args&& args, Result& u, Gradient& g) 
                     u = std::apply(f, args);
                     inner[j].val.grad = 0.0;
 
-                    H(jj, ii) = H(ii, jj) = u.grad.grad;
-                    g(ii) = static_cast<double>(u.grad);
+                    H(jj, ii) = H(ii, jj) = val(u.grad.grad);
+                    g(ii) = val(u.grad);
                 }
                 outer[i].grad = 0.0;
             }

--- a/autodiff/forward/forward.hpp
+++ b/autodiff/forward/forward.hpp
@@ -462,7 +462,7 @@ template<typename T>
 struct ValueType { using type = std::conditional_t<forward::isArithmetic<T>, T, ValueTypeInvalid>; };
 
 template<typename T, typename G>
-struct ValueType<Dual<T, G>> { using type = typename ValueType<plain<T>>::type; };
+struct ValueType<Dual<T, G>> { using type = plain<T>; };
 
 template<typename Op, typename R>
 struct ValueType<UnaryExpr<Op, R>> { using type = typename ValueType<plain<R>>::type; };
@@ -483,7 +483,7 @@ template<typename T>
 struct GradType { using type = std::conditional_t<forward::isArithmetic<T>, T, GradTypeInvalid>; };
 
 template<typename T, typename G>
-struct GradType<Dual<T, G>> { using type = typename GradType<plain<G>>::type; };
+struct GradType<Dual<T, G>> { using type = plain<G>; };
 
 template<typename Op, typename R>
 struct GradType<UnaryExpr<Op, R>> { using type = typename GradType<plain<R>>::type; };

--- a/autodiff/forward/forward.hpp
+++ b/autodiff/forward/forward.hpp
@@ -538,7 +538,8 @@ struct Dual
 
     Dual() : Dual(0.0) {}
 
-    explicit operator T() const { return this->val; }
+    template<typename U>
+    explicit operator U() const { return static_cast<U>(this->val); }
 
     template<typename U, enableif<isConvertible<U, T> && !isExpr<U>>...>
     Dual(U&& v)

--- a/test/forward.test.cpp
+++ b/test/forward.test.cpp
@@ -1079,4 +1079,135 @@ TEST_CASE("VectorXdual2nd tests", "[dual2nd]")
         for(auto i = 0; i < 3; ++i)
             REQUIRE( x(i) == approx(y(i)) );
     }
+
+    using dual2nd = HigherOrderDual<2>;
+
+    SECTION("testing gradient derivatives")
+    {
+        // Testing complex function involving sin and cos
+        auto f = [](const VectorXdual2nd& x) -> dual2nd
+        {
+            return 0.5 * ( x.array() * x.array() ).sum();
+        };
+
+        VectorXdual2nd x(3);
+        x << 1.0, 2.0, 3.0;
+
+        VectorXd g = gradient(f, wrt(x), at(x));
+
+        REQUIRE( g[0] == approx(x[0]) );
+        REQUIRE( g[1] == approx(x[1]) );
+        REQUIRE( g[2] == approx(x[2]) );
+    }
+
+    SECTION("testing jacobian derivatives")
+    {
+        // Testing complex function involving sin and cos
+        auto f = [](const VectorXdual2nd& x) -> VectorXdual2nd
+        {
+            return x / x.array().sum();
+        };
+
+        VectorXdual2nd x(3);
+        x << 0.5, 0.2, 0.3;
+
+        VectorXdual2nd F;
+
+        const MatrixXd J = jacobian(f, wrt(x), at(x), F);
+
+        for(auto i = 0; i < 3; ++i)
+            for(auto j = 0; j < 3; ++j)
+                REQUIRE( J(i, j) == approx(-F[i] + ((i == j) ? 1.0 : 0.0)) );
+    }
+
+    SECTION("testing hessian derivatives")
+    {
+        // Testing complex function involving sin and cos
+        auto f = [](const VectorXdual2nd& x) -> dual2nd
+        {
+            return 0.5 * ( x.array() * x.array() ).sum();
+        };
+
+        VectorXdual2nd x(3);
+        x << 1.0, 2.0, 3.0;
+
+        MatrixXd H = hessian(f, wrt(x), at(x));
+
+        for(auto i = 0; i < 3; ++i)
+            for(auto j = 0; j < 3; ++j)
+                REQUIRE( H(i, j) == approx(((i == j) ? 1.0 : 0.0)) );
+    }
+}
+
+TEST_CASE("VectorXdual3rd tests", "[dual3rd]")
+{
+    using dual3rd = HigherOrderDual<2>;
+    using VectorXdual3rd = Eigen::Matrix<dual3rd, -1, 1, 0, -1, 1>;
+
+    SECTION("testing casting to VectorXd")
+    {
+        VectorXdual3rd x(3);
+        x << 1.0, 2.0, 3.0;
+        
+        VectorXd y = x.template cast<double>();
+
+        for(auto i = 0; i < 3; ++i)
+            REQUIRE( x(i) == approx(y(i)) );
+    }
+
+    SECTION("testing gradient derivatives")
+    {
+        // Testing complex function involving sin and cos
+        auto f = [](const VectorXdual3rd& x) -> dual3rd
+        {
+            return 0.5 * ( x.array() * x.array() ).sum();
+        };
+
+        VectorXdual3rd x(3);
+        x << 1.0, 2.0, 3.0;
+
+        VectorXd g = gradient(f, wrt(x), at(x));
+
+        REQUIRE( g[0] == approx(x[0]) );
+        REQUIRE( g[1] == approx(x[1]) );
+        REQUIRE( g[2] == approx(x[2]) );
+    }
+
+    SECTION("testing jacobian derivatives")
+    {
+        // Testing complex function involving sin and cos
+        auto f = [](const VectorXdual3rd& x) -> VectorXdual3rd
+        {
+            return x / x.array().sum();
+        };
+
+        VectorXdual3rd x(3);
+        x << 0.5, 0.2, 0.3;
+
+        VectorXdual3rd F;
+
+        const MatrixXd J = jacobian(f, wrt(x), at(x), F);
+
+        for(auto i = 0; i < 3; ++i)
+            for(auto j = 0; j < 3; ++j)
+                REQUIRE( J(i, j) == approx(-F[i] + ((i == j) ? 1.0 : 0.0)) );
+    }
+
+    SECTION("testing hessian derivatives")
+    {
+        // Testing complex function involving sin and cos
+        auto f = [](const VectorXdual3rd& x) -> dual3rd
+        {
+            return 0.5 * ( x.array() * x.array() ).sum();
+        };
+
+        VectorXdual3rd x(3);
+        x << 1.0, 2.0, 3.0;
+
+        MatrixXd H = hessian(f, wrt(x), at(x));
+
+        for(auto i = 0; i < 3; ++i)
+            for(auto j = 0; j < 3; ++j)
+                REQUIRE( H(i, j) == approx(((i == j) ? 1.0 : 0.0)) );
+    }
 }

--- a/test/forward.test.cpp
+++ b/test/forward.test.cpp
@@ -1059,3 +1059,17 @@ TEST_CASE("Eigen::VectorXdual tests", "[dual]")
                 REQUIRE(J(i + 3, j + 4) == approx((i == j) ? y.val : 0.0));
     }
 }
+
+TEST_CASE("VectorXdual2nd tests", "[dual2nd]")
+{
+    SECTION("testing casting to VectorXd")
+    {
+        VectorXdual2nd x(3);
+        x << 1.0, 2.0, 3.0;
+        
+        VectorXd y = x.template cast<double>();
+
+        for(auto i = 0; i < 3; ++i)
+            REQUIRE( x(i) == approx(y(i)) );
+    }
+}

--- a/test/forward.test.cpp
+++ b/test/forward.test.cpp
@@ -820,6 +820,13 @@ TEST_CASE("autodiff::dual tests", "[dual]")
         REQUIRE( derivative(f, wrt(x, y, y), at(x, y)) == Approx(6.0) );
         REQUIRE( derivative(f, wrt<3>(y), at(x, y)) == Approx(6.0) );
     }
+    
+    SECTION("testing eval higher order derivatives expression")
+    {
+        using dual3rd = HigherOrderDual<3>;
+        dual3rd x = 1.5;
+        REQUIRE(2.5 == approx(x + 1.0));
+    }
 
     SECTION("testing reference to unary and binary expression nodes are not present")
     {


### PR DESCRIPTION
# Make forward mode more compatible with HigherOrderDual numbers

1. Allow cast vectors of HigherOrderDual to Eigen::VectorXd
2. Fix problem with expression eval for HigherOrderDual related to wrong recursive ValueType meta function.
3. Make Eigen related functions compatible with HigherOrderDual.