### PR TITLE
Modified build files path in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Build files
+build/
 .build/
 
 # conda

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Build files
-build/
+.build/
 
 # conda
 environment.yml


### PR DESCRIPTION
I need to use autodiff for a C++ project. When I try to install it by CMake, I found that files under the .build directory haven't be ignored yet.