### PR TITLE
Implement support for wrt(x(indices))

### DIFF
--- a/autodiff/common/eigen.hpp
+++ b/autodiff/common/eigen.hpp
@@ -99,6 +99,28 @@ struct VectorTraits<Eigen::VectorBlock<VectorType, Size>>
     using ReplaceValueType = VectorReplaceValueType<VectorType, NewValueType>;
 };
 
+#if EIGEN_VERSION_AT_LEAST(3, 3, 90)
+
+    template<typename VectorType, typename IndicesType>
+    struct VectorTraits<Eigen::IndexedView<VectorType, IndicesType, Eigen::internal::SingleRange>>
+    {
+        using ValueType = typename PlainType<VectorType>::Scalar;
+
+        template<typename NewValueType>
+        using ReplaceValueType = VectorReplaceValueType<VectorType, NewValueType>;
+    };
+
+    template<typename VectorType, typename IndicesType>
+    struct VectorTraits<Eigen::IndexedView<VectorType, Eigen::internal::SingleRange, IndicesType>>
+    {
+        using ValueType = typename PlainType<VectorType>::Scalar;
+
+        template<typename NewValueType>
+        using ReplaceValueType = VectorReplaceValueType<VectorType, NewValueType>;
+    };
+
+#endif
+
 template<typename MatrixType>
 struct VectorTraits<Eigen::Ref<MatrixType>>
 {


### PR DESCRIPTION
Implement support for `wrt(x(indices))` by defining `VectorTraits` for `Eigen::IndexedView`. This PR enables the following:

~~~c++
auto J = jacobian(f, wrt(x(indices)), at(x));
~~~

So that `J` is the Jacobian of `f` w.r.t. only `x` variables within `indices`.