### PR TITLE
Implement reverse prop condition expr

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -31,7 +31,7 @@ SpacesInCStyleCastParentheses: 'false'
 SpacesInContainerLiterals: 'false'
 SpacesInParentheses: 'false'
 SpacesInSquareBrackets: 'false'
-Standard: Cpp17
+Standard: c++17
 UseTab: Never
 
 ...

--- a/autodiff/reverse/var/var.hpp
+++ b/autodiff/reverse/var/var.hpp
@@ -275,7 +275,7 @@ struct IndependentVariableExpr : VariableExpr<T>
     /// Construct an IndependentVariableExpr object with given value.
     IndependentVariableExpr(const T& v) : VariableExpr<T>(v) {}
 
-    virtual void propagate(const T& wprime) {
+    void propagate(const T& wprime) override {
         if(gradPtr) { *gradPtr += wprime; }
     }
 
@@ -1356,7 +1356,7 @@ template<typename T, typename U, EnableIf<is_binary_expr_v<T, U>>...>
 auto operator > (const T& t, const U& u) { return comparison_operator<std::greater<>>(t, u); }
 
 //------------------------------------------------------------------------------
-// CONDITION
+// CONDITION AND RELATED FUNCTIONS
 //------------------------------------------------------------------------------
 
 template<typename T, typename U, EnableIf<is_expr_v<T> && is_expr_v<U>>...>
@@ -1366,11 +1366,10 @@ auto condition(BooleanExpr&& p, const T& t, const U& u) {
   return expr;
 }
 
-//------------------------------------------------------------------------------
-// MIN/MAX
-//------------------------------------------------------------------------------
 template<typename T, typename U, EnableIf<is_binary_expr_v<T, U>>...> auto min(const T& x, const U& y) { return condition(x < y, x, y); }
 template<typename T, typename U, EnableIf<is_binary_expr_v<T, U>>...> auto max(const T& x, const U& y) { return condition(x > y, x, y); }
+template<typename T> ExprPtr<T> sgn(const ExprPtr<T>& x) { return condition(x < 0, -1.0, condition(x > 0, 1.0, 0.0)); }
+template<typename T> ExprPtr<T> sgn(const Variable<T>& x) { return condition(x.expr < 0, -1.0, condition(x.expr > 0, 1.0, 0.0)); }
 
 //------------------------------------------------------------------------------
 // ARITHMETIC OPERATORS (DEFINED FOR ARGUMENTS OF TYPE Variable)

--- a/docs/website/tutorials.md
+++ b/docs/website/tutorials.md
@@ -69,6 +69,10 @@ suggestions on how to better demonstrate the capabilities of {{autodiff}}.
 
 {{ inputcpp('examples/reverse/example-reverse-multi-variable-function.cpp') }}
 
+### Multi-variable function with conditional
+
+{{ inputcpp('examples/reverse/example-reverse-conditional.cpp') }}
+
 ### Multi-variable function with parameters
 
 {{ inputcpp('examples/reverse/example-reverse-multi-variable-function-with-parameters.cpp') }}

--- a/examples/reverse/example-reverse-conditional.cpp
+++ b/examples/reverse/example-reverse-conditional.cpp
@@ -1,0 +1,37 @@
+// C++ includes
+#include <iostream>
+using namespace std;
+
+// autodiff include
+#include <autodiff/reverse/var.hpp>
+using namespace autodiff;
+
+// A two-variable piecewise function for which derivatives are needed
+var f(var x, var y) { return condition(x < y, x * y, x * x); }
+
+int main()
+{
+    var x = 1.0;   // the input variable x
+    var y = 2.0;   // the input variable y
+    var u = f(x, y);  // the output variable u
+    auto [ux, uy] = derivatives(u, wrt(x, y)); // evaluate the derivatives of u
+
+    cout << "x = " << x << ", y = " << y << endl;
+    cout << "u = " << u << endl;  // x = 1, y = 2, so x < y, so x * y = 2
+    cout << "ux = " << ux << endl;  // d/dx x * y = y = 2
+    cout << "uy = " << uy << endl;  // d/dy x * y = x = 1
+
+    x.update(3.0); // Change the value of x in the expression tree
+    u.update(); // Update the expression tree in a sweep
+    auto [ux2, uy2] = derivatives(u, wrt(x, y)); // re-evaluate the derivatives
+
+    cout << "x = " << x << ", y = " << y << endl;
+    cout << "u = " << u << endl;  // Now x > y, so x * x = 9
+    cout << "ux = " << ux2 << endl;  // d/dx x * x = 2x = 6
+    cout << "uy = " << uy2 << endl;  // d/dy x * x = 0
+
+    // condition-associated functions
+    cout << "min(x, y) = " << min(x, y) << endl;
+    cout << "max(x, y) = " << max(x, y) << endl;
+    cout << "sgn(x) = " << sgn(x) << endl;
+}

--- a/tests/reverse/var/var.test.cpp
+++ b/tests/reverse/var/var.test.cpp
@@ -101,6 +101,14 @@ TEST_CASE("testing autodiff::var", "[reverse][var]")
     REQUIRE( grad(c, x) == 2*val(a) * grad(a, x) + 1 );
 
     //------------------------------------------------------------------------------
+    // TEST DERIVATIVES COMPUTATION AFTER CHANGING VAR VALUE
+    //------------------------------------------------------------------------------
+    a = 20.0; // a is now a new independent variable
+
+    REQUIRE( grad(c, a) == approx(0.0) );
+    REQUIRE( grad(c, x) == 2*val(x) + 1 );
+
+    //------------------------------------------------------------------------------
     // TEST MULTIPLICATION OPERATOR (USING CONSTANT FACTOR)
     //------------------------------------------------------------------------------
     c = -2*a;
@@ -462,12 +470,12 @@ TEST_CASE("testing autodiff::var", "[reverse][var]")
     REQUIRE( condition(x > 0, x * x, x * x * x) == 4 );
     REQUIRE( grad(condition(x > 0, x * x, x * x * x), x) == approx(2 * val(x)) );
 
-    x = -2.0;
+    x.update(-2.0);
     var conditional = condition(x > 0, x * x, x * x * x);
     REQUIRE( conditional == -8 );
     REQUIRE( grad(conditional, x) == approx(3 * val(x) * val(x)) );
 
-    x = 3.0;
+    x.update(3.0);
     conditional.update();
     REQUIRE( x == 3.0 );
     REQUIRE( conditional == 9 );
@@ -476,10 +484,10 @@ TEST_CASE("testing autodiff::var", "[reverse][var]")
     // Conjunction of conditions
     var square = condition(0 <= x && x <= 1, 1.0, 0.0);
     REQUIRE( square == 0.0 );
-    x = 0.5;
+    x.update(0.5);
     square.update();
     REQUIRE( square == 1.0 );
-    x = -1.0;
+    x.update(-1.0);
     square.update();
     REQUIRE( square == 0.0 );
 

--- a/tests/reverse/var/var.test.cpp
+++ b/tests/reverse/var/var.test.cpp
@@ -491,12 +491,42 @@ TEST_CASE("testing autodiff::var", "[reverse][var]")
     square.update();
     REQUIRE( square == 0.0 );
 
+    // boolref
     bool arbitraryCondition = true;
     conditional = condition(autodiff::boolref(arbitraryCondition), 1.0, 0.0);
     REQUIRE( conditional == 1.0 );
     arbitraryCondition = false;
     conditional.update();
     REQUIRE( conditional == 0.0 );
+
+    // min/max/sgn
+    x = 1.0;
+    y = 2.0;
+    conditional = min(x, y);
+    REQUIRE(conditional == 1.0);
+    conditional = max(x, y);
+    REQUIRE(conditional == 2.0);
+    conditional = sgn(x);
+    REQUIRE(conditional == 1.0);
+
+    x.update(-1);
+    conditional.update();
+    REQUIRE(conditional == -1.0);
+
+    x.update(0);
+    conditional.update();
+    REQUIRE(conditional == 0.0);
+
+    // Gradients of conditional functions with updating
+    x = 1;
+    y = 2;
+    conditional = condition(x < y, x * y, x * x);
+    REQUIRE(grad(conditional, x) == approx(val(y)));
+    REQUIRE(grad(conditional, y) == approx(val(x)));
+    x.update(3.0);
+    conditional.update();
+    REQUIRE(grad(conditional, x) == approx(2 * val(x)));
+    REQUIRE(grad(conditional, y) == approx(0.0));
 
     //--------------------------------------------------------------------------
     // TEST OTHER FUNCTIONS


### PR DESCRIPTION
Initial implementation only, only supports simple boolean expressions
comparing Expr<T> and related classes, not yet conjunctions between
boolean expressions themselves

- Add nullary update fn to Expr<T> interface for back-propagating value
  changes in nodes of an expression tree, implement for all existing
  derived classes
- Replace virtual keyword with override in Expr<T>-derived classes
- Introduce BooleanExpr to capture arbitrary comparison between two
  Expr<T>
- Introduce ConditionalExpr to capture switching between two expressions
  depending on the value of a BooleanExpr
- Change boolean operators to return BooleanExpr's
- Alter semantics of Variable<T>::operator=(Numeric ) and
  Variable<T>::operator[+-*/]=(Numeric x) to alter the underlying
  independent variable if set without introducing a new independent
  variable expression
- Add test for condition expression
- Fix .clang-format and reformat var.hpp

Closes #88