### PR TITLE
Call VectorType.size rather than rows

### DIFF
--- a/autodiff/forward/utils/gradient.hpp
+++ b/autodiff/forward/utils/gradient.hpp
@@ -127,7 +127,7 @@ void jacobian(const Fun& f, const Wrt<Vars...>& wrt, const At<Args...>& at, Y& F
 
     ForEachWrtVar(wrt, [&](auto&& i, auto&& xi) constexpr {
         F = eval(f, at, detail::wrt(xi)); // evaluate F with xi seeded so that dF/dxi is also computed
-        if(m == 0) { m = F.rows(); J.resize(m, n); };
+        if(m == 0) { m = F.size(); J.resize(m, n); };
         for(size_t row = 0; row < m; ++row)
             J(row, i) = derivative<1>(F[row]);
     });


### PR DESCRIPTION
The following snippet does not compile against master since `std::vector` does not have a `rows` member (a la Eigen I guess). This patch fixes the issue.

```cpp
auto f = [](const auto& v){
    using Vector = std::decay_t<decltype(v)>;
    Vector ret(v.size());
    auto s = std::accumulate(v.begin(), v.end(), typename Vector::value_type(0));
    std::transform(v.begin(), v.end(), ret.begin(), [=](auto& vv){ return vv * s; });
    return ret;
  };

  std::vector<dual> x = {1,2,3,4,5};

  std::vector<dual> F;

  Eigen::MatrixXd J = jacobian(f, wrt(x), at(x), F);

  std::cout << "F = \n";
  for (const auto& v : to)
    std::cout << v << ", ";
  std::cout << "\n";

  std::cout << "J =\n" << J << "\n";
```

Current compilation error:

```terminal
autodiff/forward/utils/gradient.hpp:130:28: error: no member named 'rows' in 'std::vector<autodiff::detail::Dual<double, double>, std::allocator<autodiff::detail::Dual<double, double> > >'
        if(m == 0) { m = F.rows(); J.resize(m, n); };
```

Signed-off-by: artivis <deray.jeremie@gmail.com>