### PR TITLE
Allow sfinae specialization on VectorTraits

### DIFF
--- a/autodiff/common/vectortraits.hpp
+++ b/autodiff/common/vectortraits.hpp
@@ -47,7 +47,7 @@ template<typename V>
 struct VectorReplaceValueTypeNotSupportedFor {};
 
 /// A vector traits to be defined for each autodiff number.
-template<typename V>
+template<typename V, class Enable = void>
 struct VectorTraits
 {
     /// The value type of each entry in the vector.


### PR DESCRIPTION
[Proposal]

This small change allows for sfinea-like specialization of the `VectorTraits` struct, e.g.

```cpp
struct Foo {};

struct Bar : Foo {};
struct Blarg : Foo {};

namespace autodiff::detail {

/// Specialize VectorTraits for Foo & derived.
template <typename T> struct VectorTraits<T, EnableIf<std::is_base_of_v<Foo, T>>> { ... };

}
```

Thus offering more flexibility in the specialization.

Other traits may benefit from this feature as well but so far I did not needed to change any other to add support to `autodiff` in my project.