### PR TITLE
Fix missing dependencies in Bazel

### DIFF
--- a/autodiff/BUILD
+++ b/autodiff/BUILD
@@ -1,13 +1,13 @@
 cc_library(
     name = "common",
-    hdrs = glob(["common/eigen.hpp", "common/meta.hpp"]),
+    hdrs = glob(["common/*.hpp"]),
     deps = ["@com_github_eigen_eigen//:eigen"],
     visibility = ["//visibility:public"],
 )
 
 cc_library(
     name = "reverse",
-    hdrs = glob(["reverse.hpp", "reverse/*.hpp"]),
+    hdrs = glob(["reverse.hpp", "reverse/**/*.hpp"]),
     deps = ["@com_github_eigen_eigen//:eigen",
             ":common"],
     visibility = ["//visibility:public"],
@@ -15,7 +15,10 @@ cc_library(
 
 cc_library(
     name = "forward",
-    hdrs = glob(["forward.hpp", "forward/*.hpp"]),
-    deps = ["@com_github_eigen_eigen//:eigen"],
+    hdrs = glob(["forward.hpp", "forward/**/*.hpp"]),
+    deps = [
+        "@com_github_eigen_eigen//:eigen",
+        ":common",
+    ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Bazel requires all included header files to be listed, otherwise it reports errors such as 

```
    this rule is missing dependency declarations for the following files included by 'YOUR_PROGRAM.cpp':                               
    'external/com_github_autodiff_autodiff/autodiff/common/binomialcoefficient.hpp'                                              
    'external/com_github_autodiff_autodiff/autodiff/common/numbertraits.hpp'                                                     
    'external/com_github_autodiff_autodiff/autodiff/common/vectortraits.hpp'
```