### PR TITLE
Added T cast operator to Real

### DIFF
--- a/autodiff/forward/real/real.hpp
+++ b/autodiff/forward/real/real.hpp
@@ -95,6 +95,11 @@ public:
         return m_data[0];
     }
 
+    operator T() const
+    {
+        return (T)m_data[0];
+    }
+
     constexpr auto operator[](size_t i) -> T&
     {
         return m_data[i];


### PR DESCRIPTION
The cast operator is needed to make `std::isfinite` work on `Real`, as discussed in https://github.com/autodiff/autodiff/issues/191#. In consequence, it is now possible to compute derivatives for Eigenvalue/vector computations.