### PR TITLE
Fix chain rule in trigonometric functions when using `real`

### DIFF
--- a/autodiff/forward/real/real.hpp
+++ b/autodiff/forward/real/real.hpp
@@ -602,8 +602,12 @@ constexpr auto asin(const Real<N, T>& x)
     if constexpr (N > 0)
     {
         assert(x[0] < 1.0 && "autodiff::asin(x) has undefined derivative when |x| >= 1");
+        Real<N - 1, T> xprime;
+        For<1, N + 1>([&](auto i) constexpr {
+            xprime[i - 1] = x[i];
+        });
         Real<N - 1, T> aux(x);
-        aux = 1/sqrt(1 - aux*aux);
+        aux = xprime/sqrt(1 - aux*aux);
         For<1, N + 1>([&](auto i) constexpr {
             res[i] = aux[i - 1];
         });
@@ -619,8 +623,12 @@ constexpr auto acos(const Real<N, T>& x)
     if constexpr (N > 0)
     {
         assert(x[0] < 1.0 && "autodiff::acos(x) has undefined derivative when |x| >= 1");
+        Real<N - 1, T> xprime;
+        For<1, N + 1>([&](auto i) constexpr {
+            xprime[i - 1] = x[i];
+        });
         Real<N - 1, T> aux(x);
-        aux = -1/sqrt(1 - aux*aux);
+        aux = -xprime/sqrt(1 - aux*aux);
         For<1, N + 1>([&](auto i) constexpr {
             res[i] = aux[i - 1];
         });
@@ -635,8 +643,12 @@ constexpr auto atan(const Real<N, T>& x)
     res[0] = atan(x[0]);
     if constexpr (N > 0)
     {
+        Real<N - 1, T> xprime;
+        For<1, N + 1>([&](auto i) constexpr {
+            xprime[i - 1] = x[i];
+        });
         Real<N - 1, T> aux(x);
-        aux = 1/(1 + aux*aux);
+        aux = xprime/(1 + aux*aux);
         For<1, N + 1>([&](auto i) constexpr {
             res[i] = aux[i - 1];
         });

--- a/tests/forward/real/real.test.cpp
+++ b/tests/forward/real/real.test.cpp
@@ -267,8 +267,16 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
 
     CHECK_4TH_ORDER_REAL_NUMBERS(y, z);
 
+    //=====================================================================================================================
+    //
+    // TESTING INVERSE TRIGONOMETRIC FUNCTIONS
+    //
+    //=====================================================================================================================
+
+    real4th xprime = {{ x[1], x[2], x[3], x[4] }};
+
     y = asin(x);
-    z = 1/sqrt(1 - x*x);
+    z = xprime/sqrt(1 - x*x);
 
     CHECK_APPROX( y[0], asin(x[0]) );
     CHECK_APPROX( y[1], z[0] );
@@ -277,7 +285,7 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
     CHECK_APPROX( y[4], z[3] );
 
     y = acos(x);
-    z = -1/sqrt(1 - x*x);
+    z = -xprime/sqrt(1 - x*x);
 
     CHECK_APPROX( y[0], acos(x[0]) );
     CHECK_APPROX( y[1], z[0] );
@@ -286,7 +294,7 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
     CHECK_APPROX( y[4], z[3] );
 
     y = atan(x);
-    z = 1/(1 + x*x);
+    z = xprime/(1 + x*x);
 
     CHECK_APPROX( y[0], atan(x[0]) );
     CHECK_APPROX( y[1], z[0] );


### PR DESCRIPTION
This PR fixes the issue reported in #205 . The chain rule implemented for `asin`, `acos,` and `atan` for `autodiff::real` has now been improved to consider when the incoming `real` number argument has already been scaled or contains other derivatives.