### PR TITLE
Fix some compiler warnings

### DIFF
--- a/autodiff/forward/real/real.hpp
+++ b/autodiff/forward/real/real.hpp
@@ -854,7 +854,7 @@ auto repr(const Real<N, T>& x)
 {
     std::stringstream ss;
     ss << "autodiff.real(";
-    for(auto i = 0; i <= N; ++i)
+    for(decltype(N) i = 0; i <= N; ++i)
         ss << (i == 0 ? "" : ", ") << x[i];
     ss << ")";
     return ss.str();

--- a/autodiff/forward/utils/derivative.hpp
+++ b/autodiff/forward/utils/derivative.hpp
@@ -123,7 +123,8 @@ auto seed(const At<Args...>& at, const Along<Vecs...>& along)
         if constexpr (isVector<decltype(arg)>) {
             static_assert(isVector<decltype(dir)>);
             assert(arg.size() == dir.size());
-            for(auto i = 0; i < dir.size(); ++i)
+            size_t len = dir.size();
+            for(decltype(len) i = 0; i < len; ++i)
                 seed<1>(arg[i], dir[i]);
         }
         else seed<1>(arg, dir);
@@ -135,7 +136,8 @@ auto unseed(const At<Args...>& at)
 {
     ForEach(at.args, [&](auto& arg) constexpr {
         if constexpr (isVector<decltype(arg)>) {
-            for(auto i = 0; i < arg.size(); ++i)
+            size_t len = arg.size();
+            for(decltype(len) i = 0; i < len; ++i)
                 seed<1>(arg[i], 0.0);
         }
         else seed<1>(arg, 0.0);
@@ -181,7 +183,7 @@ auto derivative(const Vec& u)
     using T = NumericType<NumType>; // get the numeric/floating point type of the dual/real number
     using Res = VectorReplaceValueType<Vec, T>; // get the type of the vector containing numeric values instead of dual/real numbers (e.g., vector<real> becomes vector<double>, VectorXdual becomes VectorXd, etc.)
     Res res(len); // create an array to store the derivatives stored inside the dual/real number
-    for(auto i = 0; i < len; ++i)
+    for(decltype(len) i = 0; i < len; ++i)
         res[i] = derivative<order>(u[i]); // get the derivative of given order from i-th dual/real number
     return res;
 }
@@ -207,7 +209,7 @@ auto derivatives(const Result& result)
         std::array<Vec, N + 1> values; // create an array to store the derivatives stored inside the dual/real number
         For<N + 1>([&](auto i) constexpr {
             values[i].resize(len);
-            for(auto j = 0; j < len; ++j)
+            for(decltype(len) j = 0; j < len; ++j)
                 values[i][j] = derivative<i>(result[j]); // get the ith derivative of the jth dual/real number
         });
         return values;

--- a/autodiff/forward/utils/gradient.hpp
+++ b/autodiff/forward/utils/gradient.hpp
@@ -62,7 +62,6 @@ auto wrt_total_length(const Wrt<Vars...>& wrt) -> size_t
 template<typename Function, typename... Vars>
 constexpr auto ForEachWrtVar(const Wrt<Vars...>& wrt, Function&& f)
 {
-    const auto n = wrt_total_length(wrt); // the sum of lengths of all items in the wrt list
     auto i = 0; // the current index of the variable in the wrt list
     ForEach(wrt.args, [&](auto& item) constexpr
     {

--- a/tests/forward/utils/gradient.test.cpp
+++ b/tests/forward/utils/gradient.test.cpp
@@ -123,8 +123,8 @@ using namespace autodiff;
     type u; \
     VectorXd grad; \
     hessian(g, wrt(x), at(x), u, grad, map_5x5); \
-    for(size_t i = 0; i < gxx.rows(); ++i) \
-        for(size_t j = 0; j < gxx.cols(); ++j) \
+    for(Eigen::Index i = 0; i < gxx.rows(); ++i)      \
+      for(Eigen::Index j = 0; j < gxx.cols(); ++j)       \
             CHECK( gxx(i, j) == approx(map_5x5(i, j)) ); \
     /* Compute gww where w = (x1, x2, x3, x4, x0) */ \
     gww = hessian(g, wrt(x.tail(4), x[0]), at(x)); \


### PR DESCRIPTION
This PR corrects some compiler warnings:

- Removes an unused variable from `ForEachWrtVar` in `forward/utils/gradient.hpp`
- Fixes some warnings about `-Wsign-compare`, stemming from a mismatch in types between the loop index and a some size variable in several places.

After this change, I can compile cleanly with `-Wall -Werror`