### PR TITLE
Fix pip install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ CMakeLists.txt.user
 
 # Bazel
 /bazel-**
+
+# Files that contain DO-NOT-COMMIT
+*DO-NOT-COMMIT*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(CCache)
 
 # Name and details of the project
-project(autodiff VERSION 0.6.5 LANGUAGES CXX)
+project(autodiff VERSION 0.6.7 LANGUAGES CXX)
 
 # Enable parallel build if MSVC is used
 add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(CCache)
 
 # Name and details of the project
-project(autodiff VERSION 0.6.3 LANGUAGES CXX)
+project(autodiff VERSION 0.6.5 LANGUAGES CXX)
 
 # Enable parallel build if MSVC is used
 add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -9,21 +9,23 @@ dependencies:
   - catch2
   - ccache  # [unix]
   - clangxx_osx-64=11.1.0  # [osx]
-  - clcache  # [win]
-  - cmake>=3.13
-  - doxygen  # [linux]
+  - cmake
   - eigen
-  - git>=2.28
-  - graphviz  # [linux]
+  - git
   - gxx_linux-64=9.4.0  # [linux]
-  - ninja>=1.9.0
+  - ninja
   - pip
-  - pre-commit
   - pybind11
   - pybind11-abi
   - pybind11-stubgen
   - python={{ python_version }}
+  - doxygen=1.9.1  # [linux]
+  - graphviz  # [linux]
+  - pre-commit
   - shellcheck
+  - ccache  # [unix]
+  - clcache  # [win]
+  - catch2
   - vs2019_win-64  # [win]
   - pip:
     - mkdocs

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -8,11 +8,11 @@ channels:
 dependencies:
   - catch2
   - ccache  # [unix]
-  - clangxx_osx-64=11.1.0  # [osx]
+  - clangxx_osx-64=12.0.1  # [osx]
   - cmake
   - eigen
   - git
-  - gxx_linux-64=9.4.0  # [linux]
+  - gxx_linux-64=10.3.0  # [linux]
   - ninja
   - pip
   - pybind11

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -1,28 +1,31 @@
 name: autodiff
 
+{% set python_version = os.environ.get("PYTHON_VERSION", "3.9") %}
+
 channels:
   - conda-forge
 
 dependencies:
-  - gxx_linux-64=7.3.0  # [linux]
-  - clangxx=9.0.0  # [osx]
-  - cmake>=3.13
-  - ninja>=1.9.0
-  - git>=2.28
-  - eigen
-  - python
   - catch2
   - ccache  # [unix]
-  - pybind11 >=2.5.0
+  - clangxx_osx-64=11.1.0  # [osx]
+  - clcache  # [win]
+  - cmake>=3.13
+  - doxygen  # [linux]
+  - eigen
+  - git>=2.28
+  - graphviz  # [linux]
+  - gxx_linux-64=9.4.0  # [linux]
+  - ninja>=1.9.0
   - pip
+  - pre-commit
+  - pybind11
+  - pybind11-abi
+  - pybind11-stubgen
+  - python={{ python_version }}
+  - shellcheck
+  - vs2019_win-64  # [win]
   - pip:
     - mkdocs
     - mkdocs-material
     - mkdocs-macros-plugin
-  - doxygen=1.8.20                 # [linux]
-  - graphviz                       # [linux]
-  - pre-commit
-  - shellcheck
-  - ccache                         # [unix]
-  - clcache                        # [win]
-  - catch2

--- a/python/package/CMakeLists.txt
+++ b/python/package/CMakeLists.txt
@@ -1,33 +1,19 @@
-# The name of the compiled python module file as defined by pybind11 used in setup.py.in
-set(AUTODIFF_PYTHON_MODULE_FILENAME autodiff4py${PYTHON_MODULE_EXTENSION})
-
-# The path in the binary dir where the python package is assembled before it is built
-set(AUTODIFF_PYTHON_PACKAGE_PATH ${CMAKE_CURRENT_BINARY_DIR}/autodiff)
-
 # Configure the setup.py file
-set(SETUP_PY_IN ${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in)
-set(SETUP_PY ${CMAKE_CURRENT_BINARY_DIR}/setup.py)
-configure_file(${SETUP_PY_IN} ${SETUP_PY})
-
-# This is needed in Windows so that the next step produces the python package in CMAKE_BINARY_DIR\Lib\site-packages\autodiff
-file(TO_NATIVE_PATH ${CMAKE_BINARY_DIR} CMAKE_BINARY_DIR_NATIVE)
+configure_file(setup.py.in ${CMAKE_CURRENT_BINARY_DIR}/setup.py)
 
 # Create a custom target to build the python package during build stage
 add_custom_target(autodiff-setuptools ALL
+    DEPENDS autodiff4py
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/autodiff ${CMAKE_CURRENT_BINARY_DIR}/autodiff
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:autodiff4py> ${CMAKE_CURRENT_BINARY_DIR}/autodiff
-    COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} --quiet install --force --no-compile --prefix=installed/$<CONFIG>
+    COMMAND ${PYTHON_EXECUTABLE} setup.py --quiet build --force
     COMMAND ${CMAKE_COMMAND} -E rm ${CMAKE_CURRENT_BINARY_DIR}/autodiff/$<TARGET_FILE_NAME:autodiff4py>
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-# Set dependencies of the python package target
-add_dependencies(autodiff-setuptools autodiff4py)
-
 # Ensure the path where the python package is installed is not empty
 if(NOT DEFINED AUTODIFF_PYTHON_INSTALL_PREFIX)
-    set(AUTODIFF_PYTHON_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+    file(TO_NATIVE_PATH ${CMAKE_INSTALL_PREFIX} AUTODIFF_PYTHON_INSTALL_PREFIX)
 endif()
 
 # Create an install target for the autodiff python package
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/installed/$<CONFIG>/
-    DESTINATION ${AUTODIFF_PYTHON_INSTALL_PREFIX})
+install(CODE "execute_process(COMMAND pip install . --no-deps --force-reinstall --no-compile --prefix=${AUTODIFF_PYTHON_INSTALL_PREFIX} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})")

--- a/python/package/setup.py.in
+++ b/python/package/setup.py.in
@@ -1,12 +1,19 @@
 from distutils.core import setup
 
-setup(name='autodiff',
-      version='${PROJECT_VERSION}',
-      description='The Python interface of the autodiff library.',
-      author='Allan Leal',
-      author_email='allan.leal@erdw.ethz.ch',
-      url='autodiff.github.io',
-      license='MIT',
-      packages=['autodiff', 'autodiff._extensions'],
-      package_data={'autodiff': ['@AUTODIFF_PYTHON_MODULE_FILENAME@']}
-      )
+setup(
+    name='autodiff',
+    version='${PROJECT_VERSION}',
+    description='The Python interface of the autodiff library.',
+    author='Allan Leal',
+    author_email='allan.leal@erdw.ethz.ch',
+    url='autodiff.github.io',
+    license='MIT',
+    packages=['autodiff', 'autodiff._extensions'],
+    package_data={
+        'autodiff': [
+            'autodiff4py${PYTHON_MODULE_EXTENSION}',
+            'autodiff4py/*'
+            '*.pyi',
+        ],
+    }
+)


### PR DESCRIPTION
This PR improves the installation of the Python package (named `autodiff`) produced during the compilation of `autodiff`. It now uses `pip`. 