### PR TITLE
Add atan2(y,x) to autodiff::Real

### DIFF
--- a/autodiff/forward/real/real.hpp
+++ b/autodiff/forward/real/real.hpp
@@ -207,6 +207,7 @@ using std::acos;
 using std::acosh;
 using std::asin;
 using std::asinh;
+using std::atan2;
 using std::atan;
 using std::atanh;
 using std::cbrt;
@@ -651,6 +652,60 @@ constexpr auto atan(const Real<N, T>& x)
         aux = xprime/(1 + aux*aux);
         For<1, N + 1>([&](auto i) constexpr {
             res[i] = aux[i - 1];
+        });
+    }
+    return res;
+}
+
+template<size_t N, typename T, typename U, EnableIf<isArithmetic<U>>...>
+constexpr auto atan2(const U& c, const Real<N, T>& x)
+{    
+    // d[atan2(c,x)]/dx = -c / (c^2 + x^2)
+    Real<N, T> res;
+    res[0] = atan2(c, x[0]);
+    if constexpr(N > 0) {
+        Real<N - 1, T> xprime;
+        For<1, N + 1>([&](auto i) constexpr {
+            xprime[i - 1] = x[i];
+        });
+        Real<N - 1, T> aux(x);
+        aux = xprime * (-c / (c * c + aux * aux));
+        For<1, N + 1>([&](auto i) constexpr {
+            res[i] = aux[i - 1];
+        });
+    }
+    return res;
+}
+
+template<size_t N, typename T, typename U, EnableIf<isArithmetic<U>>...>
+constexpr auto atan2(const Real<N, T>& y, const U& c)
+{
+    // d[atan2(y,c)]/dy = c / (c^2 + y^2)
+    Real<N, T> res;
+    res[0] = atan2(y[0], c);
+    if constexpr(N > 0) {
+        Real<N - 1, T> yprime;
+        For<1, N + 1>([&](auto i) constexpr {
+            yprime[i - 1] = y[i];
+        });
+        Real<N - 1, T> aux(y);
+        aux = yprime * (c / (c * c + aux * aux));
+        For<1, N + 1>([&](auto i) constexpr {
+            res[i] = aux[i - 1];
+        });
+    }
+    return res;
+}
+
+template<size_t N, typename T>
+constexpr auto atan2(const Real<N, T>& y, const Real<N, T>& x)
+{
+    Real<N, T> res;
+    res[0] = atan2(y[0], x[0]);
+    if constexpr(N > 0) {
+        const T denom = x[0] * x[0] + y[0] * y[0];
+        For<1, N + 1>([&](auto i) constexpr {
+            res[i] = (x[0] * y[i] - x[i] * y[0]) / denom;
         });
     }
     return res;

--- a/tests/forward/real/real.test.cpp
+++ b/tests/forward/real/real.test.cpp
@@ -302,6 +302,39 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
     CHECK_APPROX( y[3], z[2] );
     CHECK_APPROX( y[4], z[3] );
 
+    // atan2(double, real4th)
+    constexpr double c = 2.0;
+    y = atan2(c, x);
+    z = xprime * (-c / (c * c + x * x));
+
+    CHECK_APPROX(y[0], atan2(c, x[0]));
+    CHECK_APPROX(y[1], z[0]);
+    CHECK_APPROX(y[2], z[1]);
+    CHECK_APPROX(y[3], z[2]);
+    CHECK_APPROX(y[4], z[3]);
+
+    // atan2(real4th, double)
+    y = atan2(x, c);
+    z = xprime * (c / (c * c + x * x));
+
+    CHECK_APPROX(y[0], atan2(x[0], c));
+    CHECK_APPROX(y[1], z[0]);
+    CHECK_APPROX(y[2], z[1]);
+    CHECK_APPROX(y[3], z[2]);
+    CHECK_APPROX(y[4], z[3]);
+
+    // atan2(real4th, real4th)
+    real4th yprime = {{ y[1], y[2], y[3], y[4] }};
+    
+    const real4th s = atan2(y,x);
+    z = (x[0] * yprime - y[0] * xprime) / (x[0] * x[0] + y[0] * y[0]);
+
+    CHECK_APPROX(s[0], atan2(y[0], x[0]));
+    CHECK_APPROX(s[1], z[0]);
+    CHECK_APPROX(s[2], z[1]);
+    CHECK_APPROX(s[3], z[2]);
+    CHECK_APPROX(s[4], z[3]);
+
     //=====================================================================================================================
     //
     // TESTING HYPERBOLIC FUNCTIONS


### PR DESCRIPTION
This PR adds `atan2(y,x)` to `autodiff::Real`.

Related issue https://github.com/autodiff/autodiff/issues/185