### PR TITLE
Fix backward compatibility break

### DIFF
--- a/autodiff/common/classtraits.hpp
+++ b/autodiff/common/classtraits.hpp
@@ -95,5 +95,12 @@ CREATE_MEMBER_CHECK(size);
 template<typename T>
 constexpr bool hasSize = has_member_size<PlainType<T>>::value;
 
+// Create type trait struct `has_operator_bracket`.
+template<class, typename T> struct has_operator_bracket_impl : std::false_type {};
+template<typename T> struct has_operator_bracket_impl<decltype( void(std::declval<T>().operator [](0)) ), T> : std::true_type {};
+
+/// Boolean type that is true if type T implements `operator[](int)` method.
+template<typename T> struct has_operator_bracket : has_operator_bracket_impl<void, T> {};
+
 } // namespace detail
 } // namespace autodiff

--- a/autodiff/forward/utils/gradient.hpp
+++ b/autodiff/forward/utils/gradient.hpp
@@ -32,6 +32,7 @@
 // autodiff includes
 #include <autodiff/common/eigen.hpp>
 #include <autodiff/common/meta.hpp>
+#include <autodiff/common/classtraits.hpp>
 #include <autodiff/forward/utils/derivative.hpp>
 
 namespace autodiff {
@@ -67,7 +68,12 @@ constexpr auto ForEachWrtVar(const Wrt<Vars...>& wrt, Function&& f)
     {
         if constexpr (isVector<decltype(item)>) {
             for(auto j = 0; j < item.size(); ++j)
-                f(i++, item(j)); // call given f with current index and variable from item (a vector)
+                // call given f with current index and variable from item (a vector)
+                if constexpr (detail::has_operator_bracket<decltype(item)>()) {
+                    f(i++, item[j]);
+                } else {
+                    f(i++, item(j));
+                }
         }
         else f(i++, item); // call given f with current index and variable from item (a number, not a vector)
     });

--- a/examples/forward/example-forward-gradient-derivatives.cpp
+++ b/examples/forward/example-forward-gradient-derivatives.cpp
@@ -1,0 +1,30 @@
+// C++ includes
+#include <iostream>
+#include <array>
+#include <numeric>
+
+// autodiff include
+#include <autodiff/forward/real.hpp>
+#include <autodiff/forward/real/eigen.hpp>
+using namespace autodiff;
+
+using VectorXr = std::vector<real>;
+
+// The scalar function for which the gradient is needed
+real f(VectorXr x)
+{
+    std::transform(x.begin(), x.end(), x.begin(), [](const real& r){ return r * exp(r); });
+    return std::accumulate(x.begin(), x.end(), real(0.));
+}
+
+int main()
+{
+    VectorXr x{1, 2, 3, 4, 5};                  // the input array x with 5 variables
+
+    real u;                                     // the output scalar u = f(x) evaluated together with gradient below
+
+    Eigen::VectorXd g = gradient(f, wrt(x), at(x), u); // evaluate the function value u and its gradient vector g = du/dx
+
+    std::cout << "u = " << u << std::endl;      // print the evaluated output u
+    std::cout << "g = \n" << g << std::endl;    // print the evaluated gradient vector g = du/dx
+}


### PR DESCRIPTION
#224 introduced a change in access operator call that broke backward compatibility. The compilation fails when using types that implement the `operator [](int)` but does not implement the `operator ()(int)` (such as most std containers).
The example [`example-forward-gradient-derivatives.cpp`](https://github.com/artivis/autodiff/blob/798c6e6e9545347c0d8671ecc98c87a65309ad83/examples/forward/example-forward-gradient-derivatives.cpp), introduced in this PR, wouldn't compile while `std::vector` seems to be a first-class citizen of `autodiff`.

This PR implements a traits to check whether the vector type implement the `operator [](int)` and calls it. It falls back to `operator ()(int)` otherwise.

Without more context about #224 I don't know if this fix requires further attention.

Closes #233.