### PR TITLE
CMake: Avoid check of architecture.

### DIFF
--- a/cmake/autodiffInstallCMakeConfigFiles.cmake
+++ b/cmake/autodiffInstallCMakeConfigFiles.cmake
@@ -12,7 +12,8 @@ include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     ${CMAKE_CURRENT_BINARY_DIR}/autodiffConfigVersion.cmake
     VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion)
+    COMPATIBILITY SameMajorVersion
+    ARCH_INDEPENDENT)
 
 configure_package_config_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/autodiffConfig.cmake.in


### PR DESCRIPTION
autodiff is a header only library. Therefore no check of architecture is required. If one does not disable this, CMake will complain if autodiff was built in 64 bit but later on is used by a 32 bit application.