### PR TITLE
Fix computation of reverse higher order derivatives involving `hypot(x, y)` and `hypot(x, y, z)`

### DIFF
--- a/autodiff/forward/dual/dual.hpp
+++ b/autodiff/forward/dual/dual.hpp
@@ -508,30 +508,20 @@ struct AuxCommonDualType { using type = decltype(auxCommonDualType<L, R>()); };
 template<typename T, typename G>
 struct Dual
 {
-    T val;
+    T val = {};
 
-    G grad;
+    G grad = {};
 
-    Dual() : Dual(0.0) {}
+    Dual()
+    {}
 
-    template<typename U, EnableIf<isConvertible<U, T> && !isExpr<U>>...>
-    Dual(U&& v)
-    : val(std::forward<U>(v)), grad(0)
-    {
-    }
-
-    Dual(const NumericType<T>& val)
-    : val(val), grad(0)
-    {
-    }
-
-    template<typename U, EnableIf<isExpr<U> && !isDual<U>>...>
+    template<typename U, EnableIf<isExpr<U> || isArithmetic<U>>...>
     Dual(U&& other)
     {
         assign(*this, std::forward<U>(other));
     }
 
-    template<typename U, EnableIf<isExpr<U> && !isDual<U>>...>
+    template<typename U, EnableIf<isExpr<U> || isArithmetic<U>>...>
     Dual& operator=(U&& other)
     {
         Dual tmp;
@@ -540,7 +530,7 @@ struct Dual
         return *this;
     }
 
-    template<typename U, EnableIf<isArithmetic<U> || isExpr<U>>...>
+    template<typename U, EnableIf<isExpr<U> || isArithmetic<U>>...>
     Dual& operator+=(U&& other)
     {
         Dual tmp;
@@ -549,7 +539,7 @@ struct Dual
         return *this;
     }
 
-    template<typename U, EnableIf<isArithmetic<U> || isExpr<U>>...>
+    template<typename U, EnableIf<isExpr<U> || isArithmetic<U>>...>
     Dual& operator-=(U&& other)
     {
         Dual tmp;
@@ -558,7 +548,7 @@ struct Dual
         return *this;
     }
 
-    template<typename U, EnableIf<isArithmetic<U> || isExpr<U>>...>
+    template<typename U, EnableIf<isExpr<U> || isArithmetic<U>>...>
     Dual& operator*=(U&& other)
     {
         Dual tmp;
@@ -567,7 +557,7 @@ struct Dual
         return *this;
     }
 
-    template<typename U, EnableIf<isArithmetic<U> || isExpr<U>>...>
+    template<typename U, EnableIf<isExpr<U> || isArithmetic<U>>...>
     Dual& operator/=(U&& other)
     {
         Dual tmp;

--- a/autodiff/reverse/var/var.hpp
+++ b/autodiff/reverse/var/var.hpp
@@ -1033,14 +1033,14 @@ struct Hypot2Expr : BinaryExpr<T>
 
     void propagate(const T& wprime) override
     {
-        l->propagate(wprime * l->val / val);
-        r->propagate(wprime * r->val / val);
+        l->propagate(wprime * l->val / val); // sqrt(l*l + r*r)'l = 1/2 * 1/sqrt(l*l + r*r) * (2*l*l') = (l*l')/sqrt(l*l + r*r)
+        r->propagate(wprime * r->val / val); // sqrt(l*l + r*r)'r = 1/2 * 1/sqrt(l*l + r*r) * (2*r*r') = (r*r')/sqrt(l*l + r*r)
     }
 
     void propagatex(const ExprPtr<T>& wprime) override
     {
-        l->propagatex(wprime * l / val);
-        r->propagatex(wprime * r / val);
+        l->propagatex(wprime * l / hypot(l, r));
+        r->propagatex(wprime * r / hypot(l, r));
     }
 
     void update() override
@@ -1071,9 +1071,9 @@ struct Hypot3Expr : TernaryExpr<T>
 
     void propagatex(const ExprPtr<T>& wprime) override
     {
-        l->propagatex(wprime * l / val);
-        c->propagatex(wprime * c / val);
-        r->propagatex(wprime * r / val);
+        l->propagatex(wprime * l / hypot(l, c, r));
+        c->propagatex(wprime * c / hypot(l, c, r));
+        r->propagatex(wprime * r / hypot(l, c, r));
     }
 
     void update() override

--- a/autodiff/reverse/var/var.hpp
+++ b/autodiff/reverse/var/var.hpp
@@ -427,8 +427,8 @@ struct SubExpr : BinaryExpr<T>
 
     void propagatex(const ExprPtr<T>& wprime) override
     {
-        l->propagatex(wprime);
-        r->propagatex(-wprime);
+        l->propagatex(wprime);  // (l - r)'l =  l'
+        r->propagatex(-wprime); // (l - r)'r = -r'
     }
 
     void update() override
@@ -449,8 +449,8 @@ struct MulExpr : BinaryExpr<T>
 
     void propagate(const T& wprime) override
     {
-        l->propagate(wprime * r->val);
-        r->propagate(wprime * l->val);
+        l->propagate(wprime * r->val); // (l * r)'l = w' * r
+        r->propagate(wprime * l->val); // (l * r)'r = l * w'
     }
 
     void propagatex(const ExprPtr<T>& wprime) override
@@ -769,7 +769,7 @@ struct ExpExpr : UnaryExpr<T>
 
     void propagate(const T& wprime) override
     {
-        x->propagate(wprime * val);
+        x->propagate(wprime * val); // exp(x)' = exp(x) * x'
     }
 
     void propagatex(const ExprPtr<T>& wprime) override
@@ -793,7 +793,7 @@ struct LogExpr : UnaryExpr<T>
 
     void propagate(const T& wprime) override
     {
-        x->propagate(wprime / x->val);
+        x->propagate(wprime / x->val); // log(x)' = x'/x
     }
 
     void propagatex(const ExprPtr<T>& wprime) override
@@ -922,7 +922,7 @@ struct PowConstantRightExpr : BinaryExpr<T>
 
     void propagate(const T& wprime) override
     {
-        l->propagate(wprime * pow(l->val, r->val - 1) * r->val);
+        l->propagate(wprime * pow(l->val, r->val - 1) * r->val); // pow(l, r)'l = r * pow(l, r - 1) * l'
     }
 
     void propagatex(const ExprPtr<T>& wprime) override
@@ -947,7 +947,7 @@ struct SqrtExpr : UnaryExpr<T>
 
     void propagate(const T& wprime) override
     {
-        x->propagate(wprime / (2.0 * sqrt(x->val)));
+        x->propagate(wprime / (2.0 * sqrt(x->val))); // sqrt(x)' = 1/2 * 1/sqrt(x) * x'
     }
 
     void propagatex(const ExprPtr<T>& wprime) override
@@ -1004,7 +1004,7 @@ struct ErfExpr : UnaryExpr<T>
 
     void propagate(const T& wprime) override
     {
-        const auto aux = 2.0 / sqrt_pi * exp(-(x->val) * (x->val));
+        const auto aux = 2.0 / sqrt_pi * exp(-(x->val) * (x->val)); // erf(x)' = 2/sqrt(pi) * exp(-x * x) * x'
         x->propagate(wprime * aux);
     }
 

--- a/tests/reverse/var/var.test.cpp
+++ b/tests/reverse/var/var.test.cpp
@@ -545,6 +545,10 @@ TEST_CASE("testing autodiff::var", "[reverse][var]")
     //--------------------------------------------------------------------------
     // TEST HIGHER ORDER DERIVATIVES (2nd order)
     //--------------------------------------------------------------------------
+    x = 0.5;
+    y = 0.7;
+    z = 0.3;
+
     REQUIRE( val(gradx(gradx(x * x, x), x)) == Approx(2.0) );
     REQUIRE( val(gradx(gradx(1.0/x, x), x)) == Approx(val(2.0/(x * x * x))) );
     REQUIRE( val(gradx(gradx(sin(x), x), x)) == Approx(val(-sin(x))) );
@@ -555,6 +559,21 @@ TEST_CASE("testing autodiff::var", "[reverse][var]")
     REQUIRE( val(gradx(gradx(pow(2.0, x), x), x)) == Approx(val(std::log(2.0) * std::log(2.0) * pow(2.0, x))) );
     REQUIRE( val(gradx(gradx(pow(x, x), x), x)) == Approx(val(((log(x) + 1) * (log(x) + 1) + 1.0/x) * pow(x, x))) );
     REQUIRE( val(gradx(gradx(sqrt(x), x), x)) == Approx(val(-0.25 / (x * sqrt(x)))) );
+
+    REQUIRE( val(gradx(gradx(hypot(x, y), x), x)) == Approx(val(grad(x / hypot(x, y), x))) ); // hypot(x, y)'x = 1/2 * 1/hypot(x, y) * (2*x) = x/hypot(x, y)
+    REQUIRE( val(gradx(gradx(hypot(x, y), x), y)) == Approx(val(grad(x / hypot(x, y), y))) ); // hypot(x, y)'y = 1/2 * 1/hypot(x, y) * (2*y) = y/hypot(x, y)
+    REQUIRE( val(gradx(gradx(hypot(x, y), y), x)) == Approx(val(grad(y / hypot(x, y), x))) );
+    REQUIRE( val(gradx(gradx(hypot(x, y), y), y)) == Approx(val(grad(y / hypot(x, y), y))) );
+
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), x), x)) == Approx(val(grad(x / hypot(x, y, z), x))) ); // hypot(x, y, z)'x = 1/2 * 1/hypot(x, y, z) * (2*x) = x/hypot(x, y, z)
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), x), y)) == Approx(val(grad(x / hypot(x, y, z), y))) ); // hypot(x, y, z)'y = 1/2 * 1/hypot(x, y, z) * (2*y) = y/hypot(x, y, z)
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), x), z)) == Approx(val(grad(x / hypot(x, y, z), z))) ); // hypot(x, y, z)'z = 1/2 * 1/hypot(x, y, z) * (2*z) = z/hypot(x, y, z)
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), y), x)) == Approx(val(grad(y / hypot(x, y, z), x))) );
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), y), y)) == Approx(val(grad(y / hypot(x, y, z), y))) );
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), y), z)) == Approx(val(grad(y / hypot(x, y, z), z))) );
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), z), x)) == Approx(val(grad(z / hypot(x, y, z), x))) );
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), z), y)) == Approx(val(grad(z / hypot(x, y, z), y))) );
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), z), z)) == Approx(val(grad(z / hypot(x, y, z), z))) );
 
     //--------------------------------------------------------------------------
     // TEST HIGHER ORDER DERIVATIVES (3rd order)


### PR DESCRIPTION
This PR fixes the issue reported in #243 in which higher-order derivatives for `hypot` function was not correct.

With the changes included here, the following code works as expected:

~~~c++
#include <autodiff/reverse/var.hpp>
#include <iostream>

using namespace autodiff;

int main()
{
    var x = 1.0;
    var y = 1.0;

    {
        var u = hypot(x, y);

        auto [ux, uy] = derivativesx(u, wrt(x, y));
        auto [uxx, uxy] = derivativesx(ux, wrt(x, y));
        auto [uyx, uyy] = derivativesx(uy, wrt(x, y));
        std::cout << "u = " << u << std::endl;
        std::cout << "ux = " << ux << "\nuy = " << uy << std::endl;
        std::cout << "[uxx, uxy] = [" << uxx << ", " << uxy << "]\n"
                  << "[uyx, uyy] = [" << uyx << ", " << uyy << "]" << std::endl;
    }

    {
        var u = sqrt(x * x + y * y);

        auto [ux, uy] = derivativesx(u, wrt(x, y));
        auto [uxx, uxy] = derivativesx(ux, wrt(x, y));
        auto [uyx, uyy] = derivativesx(uy, wrt(x, y));
        std::cout << "u = " << u << std::endl;
        std::cout << "ux = " << ux << "\nuy = " << uy << std::endl;
        std::cout << "[uxx, uxy] = [" << uxx << ", " << uxy << "]\n"
                  << "[uyx, uyy] = [" << uyx << ", " << uyy << "]" << std::endl;
    }
}
~~~

and outputs:

~~~text
u = 1.41421
ux = 0.707107
uy = 0.707107
[uxx, uxy] = [0.353553, -0.353553]
[uyx, uyy] = [-0.353553, 0.353553]

u = 1.41421
ux = 0.707107
uy = 0.707107
[uxx, uxy] = [0.353553, -0.353553]
[uyx, uyy] = [-0.353553, 0.353553]
~~~

which matching values.