### PR TITLE
Migrate Catch2 from v2 to v3

### DIFF
--- a/docs/website/installation.md
+++ b/docs/website/installation.md
@@ -15,7 +15,7 @@ conda install conda-forge::autodiff
 This will install {{autodiff}} in the conda environment that is active at the
 moment (e.g., the default conda environment is named `base`).
 
-### Developement Environment
+### Development Environment
 
 [Anaconda] or [Miniconda] can be used to create a full development environment using [conda-devenv].
 

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - catch2=2
+  - catch2>=3
   - ccache  # [unix]
   - clangxx_osx-64  # [osx]
   - cmake

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,8 +6,11 @@ add_executable(autodiff-cpptests main.cpp ${TEST_FILES})
 target_link_libraries(autodiff-cpptests autodiff::autodiff Eigen3::Eigen Catch2::Catch2WithMain)
 set_target_properties(autodiff-cpptests PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
 
-include(Catch)
-catch_discover_tests(autodiff-cpptests)
+# Add target tests that performs all C++ and Python tests
+add_custom_target(tests
+    COMMENT "Running C++ tests..."
+    COMMAND $<TARGET_FILE:autodiff-cpptests>
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 if(AUTODIFF_TEST_SANITIZE)
     include(CheckCXXCompilerFlag)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,16 +1,13 @@
 find_package(Eigen3 REQUIRED)
-find_package(Catch2 REQUIRED)
+find_package(Catch2 3 REQUIRED)
 
 file(GLOB_RECURSE TEST_FILES "*.test.cpp")
 add_executable(autodiff-cpptests main.cpp ${TEST_FILES})
-target_link_libraries(autodiff-cpptests autodiff::autodiff Eigen3::Eigen Catch2::Catch2)
+target_link_libraries(autodiff-cpptests autodiff::autodiff Eigen3::Eigen Catch2::Catch2WithMain)
 set_target_properties(autodiff-cpptests PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
 
-# Add target tests that performs all C++ and Python tests
-add_custom_target(tests
-    COMMENT "Running C++ tests..."
-    COMMAND $<TARGET_FILE:autodiff-cpptests>
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+include(Catch)
+catch_discover_tests(autodiff-cpptests)
 
 if(AUTODIFF_TEST_SANITIZE)
     include(CheckCXXCompilerFlag)

--- a/tests/common/meta.test.cpp
+++ b/tests/common/meta.test.cpp
@@ -28,7 +28,7 @@
 // SOFTWARE.
 
 // Catch includes
-#include <catch2/catch_all.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 // autodiff includes
 #include <autodiff/common/meta.hpp>

--- a/tests/common/meta.test.cpp
+++ b/tests/common/meta.test.cpp
@@ -28,7 +28,7 @@
 // SOFTWARE.
 
 // Catch includes
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 // autodiff includes
 #include <autodiff/common/meta.hpp>

--- a/tests/forward/dual/dual.test.cpp
+++ b/tests/forward/dual/dual.test.cpp
@@ -28,7 +28,8 @@
 // SOFTWARE.
 
 // Catch includes
-#include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 // autodiff includes
 #include <autodiff/forward/dual.hpp>

--- a/tests/forward/dual/dual.test.cpp
+++ b/tests/forward/dual/dual.test.cpp
@@ -28,16 +28,16 @@
 // SOFTWARE.
 
 // Catch includes
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 // autodiff includes
 #include <autodiff/forward/dual.hpp>
 using namespace autodiff;
 
 template<typename T>
-auto approx(T&& expr) -> Approx
+auto approx(T&& expr) -> Catch::Approx
 {
-    return Approx(val(std::forward<T>(expr))).margin(1e-12);
+    return Catch::Approx(val(std::forward<T>(expr))).margin(1e-12);
 }
 
 #define CHECK_DERIVATIVES_FX(expr, u, ux)         \

--- a/tests/forward/dual/eigen.test.cpp
+++ b/tests/forward/dual/eigen.test.cpp
@@ -28,7 +28,8 @@
 // SOFTWARE.
 
 // Catch includes
-#include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 // autodiff includes
 #include <autodiff/forward/dual.hpp>

--- a/tests/forward/dual/eigen.test.cpp
+++ b/tests/forward/dual/eigen.test.cpp
@@ -28,7 +28,7 @@
 // SOFTWARE.
 
 // Catch includes
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 // autodiff includes
 #include <autodiff/forward/dual.hpp>
@@ -36,10 +36,10 @@
 using namespace autodiff;
 
 template<typename T>
-auto approx(T&& expr) -> Approx
+auto approx(T&& expr) -> Catch::Approx
 {
     const double zero = std::numeric_limits<double>::epsilon();
-    return Approx(val(std::forward<T>(expr))).margin(zero);
+    return Catch::Approx(val(std::forward<T>(expr))).margin(zero);
 }
 
 TEST_CASE("testing autodiff::dual (with eigen)", "[forward][dual][eigen]")

--- a/tests/forward/utils/derivative.test.cpp
+++ b/tests/forward/utils/derivative.test.cpp
@@ -30,12 +30,14 @@
 // C++ includes
 #include <vector>
 
+// Catch includes
+#include <catch2/catch_test_macros.hpp>
+
 // autodiff includes
 #include <autodiff/forward/dual.hpp>
 #include <autodiff/forward/dual/eigen.hpp>
 #include <autodiff/forward/real.hpp>
 #include <autodiff/forward/real/eigen.hpp>
-#include <tests/utils/catch.hpp>
 using namespace autodiff;
 
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,6 +1,3 @@
 #ifdef __clang__
 #define CATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS // Prevents error: 'uncaught_exceptions' is unavailable: introduced in macOS 10.12 (see discussion at https://github.com/catchorg/Catch2/issues/1218)
 #endif
-
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>

--- a/tests/reverse/var/eigen.test.cpp
+++ b/tests/reverse/var/eigen.test.cpp
@@ -28,7 +28,7 @@
 // SOFTWARE.
 
 // Catch includes
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 // autodiff includes
 #include <autodiff/reverse/var.hpp>
@@ -44,9 +44,9 @@ using Eigen::MatrixXd;
 using Eigen::VectorXd;
 
 template<typename Var>
-auto approx(const Var& x) -> Approx
+auto approx(const Var& x) -> Catch::Approx
 {
-    return Approx(val(x));
+    return Catch::Approx(val(x));
 }
 
 TEST_CASE("testing autodiff::var (with eigen)", "[reverse][var][eigen]")
@@ -108,9 +108,9 @@ TEST_CASE("testing autodiff::var (with eigen)", "[reverse][var][eigen]")
         CHECK( val(g[i]) == approx(y / tan(x[i])) );
         for(auto j = 0; j < x.size(); ++j)
             if(i == j)
-                CHECK( H(i, j) == Approx(val(g[i] / tan(x[i]) * (1.0 - 1.0/(cos(x[i]) * cos(x[i]))))) );
+                CHECK( H(i, j) == Catch::Approx(val(g[i] / tan(x[i]) * (1.0 - 1.0/(cos(x[i]) * cos(x[i]))))) );
             else
-                CHECK( H(i, j) == Approx(val(g[j] / tan(x[i]))) );
+                CHECK( H(i, j) == Catch::Approx(val(g[j] / tan(x[i]))) );
     }
 
     //--------------------------------------------------------------------------

--- a/tests/reverse/var/eigen.test.cpp
+++ b/tests/reverse/var/eigen.test.cpp
@@ -28,7 +28,8 @@
 // SOFTWARE.
 
 // Catch includes
-#include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 // autodiff includes
 #include <autodiff/reverse/var.hpp>

--- a/tests/reverse/var/var.test.cpp
+++ b/tests/reverse/var/var.test.cpp
@@ -28,7 +28,7 @@
 // SOFTWARE.
 
 // Catch includes
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 // autodiff includes
 #include <autodiff/reverse/var.hpp>
@@ -52,9 +52,9 @@ inline auto gradx(const var& y, var& x)
 }
 
 template<typename Var>
-auto approx(const Var& x) -> Approx
+auto approx(const Var& x) -> Catch::Approx
 {
-    return Approx(val(x));
+    return Catch::Approx(val(x));
 }
 
 TEST_CASE("testing autodiff::var", "[reverse][var]")
@@ -311,27 +311,27 @@ TEST_CASE("testing autodiff::var", "[reverse][var]")
     //--------------------------------------------------------------------------
     // TEST POWER FUNCTIONS
     //--------------------------------------------------------------------------
-    REQUIRE( val(sqrt(x)) == Approx(std::sqrt(val(x))) );
-    REQUIRE( grad(sqrt(x), x) == Approx(0.5 / std::sqrt(val(x))) );
+    REQUIRE( val(sqrt(x)) == Catch::Approx(std::sqrt(val(x))) );
+    REQUIRE( grad(sqrt(x), x) == Catch::Approx(0.5 / std::sqrt(val(x))) );
 
-    REQUIRE( val(pow(x, 2.0)) == Approx(std::pow(val(x), 2.0)) );
-    REQUIRE( grad(pow(x, 2.0), x) == Approx(2.0 * val(x)) );
+    REQUIRE( val(pow(x, 2.0)) == Catch::Approx(std::pow(val(x), 2.0)) );
+    REQUIRE( grad(pow(x, 2.0), x) == Catch::Approx(2.0 * val(x)) );
 
-    REQUIRE( val(pow(2.0, x)) == Approx(std::pow(2.0, val(x))) );
-    REQUIRE( grad(pow(2.0, x), x) == Approx(std::log(2.0) * std::pow(2.0, val(x))) );
+    REQUIRE( val(pow(2.0, x)) == Catch::Approx(std::pow(2.0, val(x))) );
+    REQUIRE( grad(pow(2.0, x), x) == Catch::Approx(std::log(2.0) * std::pow(2.0, val(x))) );
 
-    REQUIRE( val(pow(x, x)) == Approx(std::pow(val(x), val(x))) );
-    REQUIRE( grad(pow(x, x), x) == Approx(val((log(x) + 1) * pow(x, x))) );
+    REQUIRE( val(pow(x, x)) == Catch::Approx(std::pow(val(x), val(x))) );
+    REQUIRE( grad(pow(x, x), x) == Catch::Approx(val((log(x) + 1) * pow(x, x))) );
 
     y = 2 * a;
 
-    REQUIRE( y == Approx( 2 * val(a) ) );
-    REQUIRE( grad(y, a) == Approx( 2.0 ) );
+    REQUIRE( y == Catch::Approx( 2 * val(a) ) );
+    REQUIRE( grad(y, a) == Catch::Approx( 2.0 ) );
 
-    REQUIRE( val(pow(x, y)) == Approx(std::pow(val(x), val(y))) );
-    REQUIRE( grad(pow(x, y), x) == Approx( val(y)/val(x) * std::pow(val(x), val(y)) ) );
-    REQUIRE( grad(pow(x, y), a) == Approx( std::pow(val(x), val(y)) * (val(y)/val(x) * grad(x, a) + std::log(val(x)) * grad(y, a)) ) );
-    REQUIRE( grad(pow(x, y), y) == Approx( std::log(val(x)) * std::pow(val(x), val(y)) ) );
+    REQUIRE( val(pow(x, y)) == Catch::Approx(std::pow(val(x), val(y))) );
+    REQUIRE( grad(pow(x, y), x) == Catch::Approx( val(y)/val(x) * std::pow(val(x), val(y)) ) );
+    REQUIRE( grad(pow(x, y), a) == Catch::Approx( std::pow(val(x), val(y)) * (val(y)/val(x) * grad(x, a) + std::log(val(x)) * grad(y, a)) ) );
+    REQUIRE( grad(pow(x, y), y) == Catch::Approx( std::log(val(x)) * std::pow(val(x), val(y)) ) );
 
 
     //--------------------------------------------------------------------------
@@ -534,8 +534,8 @@ TEST_CASE("testing autodiff::var", "[reverse][var]")
     x = 3.0;
     y = x;
 
-    REQUIRE( val(abs(x)) == Approx(std::abs(val(x))) );
-    REQUIRE( grad(x, x) == Approx(1.0) );
+    REQUIRE( val(abs(x)) == Catch::Approx(std::abs(val(x))) );
+    REQUIRE( grad(x, x) == Catch::Approx(1.0) );
 
     x = 0.5;
     constexpr double pi = 3.141592653589793238462643383279502884197169399375105820974;
@@ -549,31 +549,31 @@ TEST_CASE("testing autodiff::var", "[reverse][var]")
     y = 0.7;
     z = 0.3;
 
-    REQUIRE( val(gradx(gradx(x * x, x), x)) == Approx(2.0) );
-    REQUIRE( val(gradx(gradx(1.0/x, x), x)) == Approx(val(2.0/(x * x * x))) );
-    REQUIRE( val(gradx(gradx(sin(x), x), x)) == Approx(val(-sin(x))) );
-    REQUIRE( val(gradx(gradx(cos(x), x), x)) == Approx(val(-cos(x))) );
-    REQUIRE( val(gradx(gradx(log(x), x), x)) == Approx(val(-1.0/(x * x))) );
-    REQUIRE( val(gradx(gradx(exp(x), x), x)) == Approx(val(exp(x))) );
-    REQUIRE( val(gradx(gradx(pow(x, 2.0), x), x)) == Approx(2.0) );
-    REQUIRE( val(gradx(gradx(pow(2.0, x), x), x)) == Approx(val(std::log(2.0) * std::log(2.0) * pow(2.0, x))) );
-    REQUIRE( val(gradx(gradx(pow(x, x), x), x)) == Approx(val(((log(x) + 1) * (log(x) + 1) + 1.0/x) * pow(x, x))) );
-    REQUIRE( val(gradx(gradx(sqrt(x), x), x)) == Approx(val(-0.25 / (x * sqrt(x)))) );
+    REQUIRE( val(gradx(gradx(x * x, x), x)) == Catch::Approx(2.0) );
+    REQUIRE( val(gradx(gradx(1.0/x, x), x)) == Catch::Approx(val(2.0/(x * x * x))) );
+    REQUIRE( val(gradx(gradx(sin(x), x), x)) == Catch::Approx(val(-sin(x))) );
+    REQUIRE( val(gradx(gradx(cos(x), x), x)) == Catch::Approx(val(-cos(x))) );
+    REQUIRE( val(gradx(gradx(log(x), x), x)) == Catch::Approx(val(-1.0/(x * x))) );
+    REQUIRE( val(gradx(gradx(exp(x), x), x)) == Catch::Approx(val(exp(x))) );
+    REQUIRE( val(gradx(gradx(pow(x, 2.0), x), x)) == Catch::Approx(2.0) );
+    REQUIRE( val(gradx(gradx(pow(2.0, x), x), x)) == Catch::Approx(val(std::log(2.0) * std::log(2.0) * pow(2.0, x))) );
+    REQUIRE( val(gradx(gradx(pow(x, x), x), x)) == Catch::Approx(val(((log(x) + 1) * (log(x) + 1) + 1.0/x) * pow(x, x))) );
+    REQUIRE( val(gradx(gradx(sqrt(x), x), x)) == Catch::Approx(val(-0.25 / (x * sqrt(x)))) );
 
-    REQUIRE( val(gradx(gradx(hypot(x, y), x), x)) == Approx(val(grad(x / hypot(x, y), x))) ); // hypot(x, y)'x = 1/2 * 1/hypot(x, y) * (2*x) = x/hypot(x, y)
-    REQUIRE( val(gradx(gradx(hypot(x, y), x), y)) == Approx(val(grad(x / hypot(x, y), y))) ); // hypot(x, y)'y = 1/2 * 1/hypot(x, y) * (2*y) = y/hypot(x, y)
-    REQUIRE( val(gradx(gradx(hypot(x, y), y), x)) == Approx(val(grad(y / hypot(x, y), x))) );
-    REQUIRE( val(gradx(gradx(hypot(x, y), y), y)) == Approx(val(grad(y / hypot(x, y), y))) );
+    REQUIRE( val(gradx(gradx(hypot(x, y), x), x)) == Catch::Approx(val(grad(x / hypot(x, y), x))) ); // hypot(x, y)'x = 1/2 * 1/hypot(x, y) * (2*x) = x/hypot(x, y)
+    REQUIRE( val(gradx(gradx(hypot(x, y), x), y)) == Catch::Approx(val(grad(x / hypot(x, y), y))) ); // hypot(x, y)'y = 1/2 * 1/hypot(x, y) * (2*y) = y/hypot(x, y)
+    REQUIRE( val(gradx(gradx(hypot(x, y), y), x)) == Catch::Approx(val(grad(y / hypot(x, y), x))) );
+    REQUIRE( val(gradx(gradx(hypot(x, y), y), y)) == Catch::Approx(val(grad(y / hypot(x, y), y))) );
 
-    REQUIRE( val(gradx(gradx(hypot(x, y, z), x), x)) == Approx(val(grad(x / hypot(x, y, z), x))) ); // hypot(x, y, z)'x = 1/2 * 1/hypot(x, y, z) * (2*x) = x/hypot(x, y, z)
-    REQUIRE( val(gradx(gradx(hypot(x, y, z), x), y)) == Approx(val(grad(x / hypot(x, y, z), y))) ); // hypot(x, y, z)'y = 1/2 * 1/hypot(x, y, z) * (2*y) = y/hypot(x, y, z)
-    REQUIRE( val(gradx(gradx(hypot(x, y, z), x), z)) == Approx(val(grad(x / hypot(x, y, z), z))) ); // hypot(x, y, z)'z = 1/2 * 1/hypot(x, y, z) * (2*z) = z/hypot(x, y, z)
-    REQUIRE( val(gradx(gradx(hypot(x, y, z), y), x)) == Approx(val(grad(y / hypot(x, y, z), x))) );
-    REQUIRE( val(gradx(gradx(hypot(x, y, z), y), y)) == Approx(val(grad(y / hypot(x, y, z), y))) );
-    REQUIRE( val(gradx(gradx(hypot(x, y, z), y), z)) == Approx(val(grad(y / hypot(x, y, z), z))) );
-    REQUIRE( val(gradx(gradx(hypot(x, y, z), z), x)) == Approx(val(grad(z / hypot(x, y, z), x))) );
-    REQUIRE( val(gradx(gradx(hypot(x, y, z), z), y)) == Approx(val(grad(z / hypot(x, y, z), y))) );
-    REQUIRE( val(gradx(gradx(hypot(x, y, z), z), z)) == Approx(val(grad(z / hypot(x, y, z), z))) );
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), x), x)) == Catch::Approx(val(grad(x / hypot(x, y, z), x))) ); // hypot(x, y, z)'x = 1/2 * 1/hypot(x, y, z) * (2*x) = x/hypot(x, y, z)
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), x), y)) == Catch::Approx(val(grad(x / hypot(x, y, z), y))) ); // hypot(x, y, z)'y = 1/2 * 1/hypot(x, y, z) * (2*y) = y/hypot(x, y, z)
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), x), z)) == Catch::Approx(val(grad(x / hypot(x, y, z), z))) ); // hypot(x, y, z)'z = 1/2 * 1/hypot(x, y, z) * (2*z) = z/hypot(x, y, z)
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), y), x)) == Catch::Approx(val(grad(y / hypot(x, y, z), x))) );
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), y), y)) == Catch::Approx(val(grad(y / hypot(x, y, z), y))) );
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), y), z)) == Catch::Approx(val(grad(y / hypot(x, y, z), z))) );
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), z), x)) == Catch::Approx(val(grad(z / hypot(x, y, z), x))) );
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), z), y)) == Catch::Approx(val(grad(z / hypot(x, y, z), y))) );
+    REQUIRE( val(gradx(gradx(hypot(x, y, z), z), z)) == Catch::Approx(val(grad(z / hypot(x, y, z), z))) );
 
     //--------------------------------------------------------------------------
     // TEST HIGHER ORDER DERIVATIVES (3rd order)

--- a/tests/reverse/var/var.test.cpp
+++ b/tests/reverse/var/var.test.cpp
@@ -34,7 +34,7 @@
 // autodiff includes
 #include <autodiff/reverse/var.hpp>
 
-    using autodiff::derivatives;
+using autodiff::derivatives;
 using autodiff::val;
 using autodiff::var;
 using autodiff::wrt;

--- a/tests/reverse/var/var.test.cpp
+++ b/tests/reverse/var/var.test.cpp
@@ -28,12 +28,13 @@
 // SOFTWARE.
 
 // Catch includes
-#include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 // autodiff includes
 #include <autodiff/reverse/var.hpp>
 
-using autodiff::derivatives;
+    using autodiff::derivatives;
 using autodiff::val;
 using autodiff::var;
 using autodiff::wrt;

--- a/tests/utils/catch.hpp
+++ b/tests/utils/catch.hpp
@@ -30,13 +30,13 @@
 #pragma once
 
 // Catch includes
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 template<typename T>
-auto approx(T&& number) -> Approx
+auto approx(T&& number) -> Catch::Approx
 {
     const double val = static_cast<double>(number);
-    return Approx(val).margin(1e-12);
+    return Catch::Approx(val).margin(1e-12);
 }
 
 #define CHECK_APPROX(a, b) CHECK(a == approx(b))

--- a/tests/utils/catch.hpp
+++ b/tests/utils/catch.hpp
@@ -30,7 +30,8 @@
 #pragma once
 
 // Catch includes
-#include <catch2/catch_all.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 template<typename T>
 auto approx(T&& number) -> Catch::Approx


### PR DESCRIPTION
This PR migrates Catch2 from v2 to v3, following the [migration instructions](https://github.com/catchorg/Catch2/blob/devel/docs/migrate-v2-to-v3.md#top).

@allanleal Catch is also used in `test/BUILD`. I see in the [installation instructions](https://autodiff.github.io/installation/) that this is for the [Bazel](https://bazel.build/) build system. I never used it before and I can't see it in the CI builds; is there any documentation related to `autodiff` about this?

Fix #246 