### PR TITLE
Support the use of `Eigen::Map`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(CCache)
 
 # Name and details of the project
-project(autodiff VERSION 0.6.8 LANGUAGES CXX)
+project(autodiff VERSION 0.6.12 LANGUAGES CXX)
 
 # Enable parallel build if MSVC is used
 add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)

--- a/autodiff/common/eigen.hpp
+++ b/autodiff/common/eigen.hpp
@@ -130,6 +130,15 @@ struct VectorTraits<Eigen::Ref<MatrixType>>
     using ReplaceValueType = VectorReplaceValueType<MatrixType, NewValueType>;
 };
 
+template<typename VectorType, int MapOptions, typename StrideType>
+struct VectorTraits<Eigen::Map<VectorType, MapOptions, StrideType>>
+{
+    using ValueType = VectorValueType<VectorType>;
+
+    template<typename NewValueType>
+    using ReplaceValueType = Eigen::Map<VectorReplaceValueType<VectorType, NewValueType>, MapOptions, StrideType>;
+};
+
 //=====================================================================================================================
 //
 // AUXILIARY TEMPLATE TYPE ALIASES

--- a/autodiff/common/meta.hpp
+++ b/autodiff/common/meta.hpp
@@ -52,6 +52,9 @@ using CommonType = typename std::common_type<A, B>::type;
 template<typename Fun, typename... Args>
 using ReturnType = std::invoke_result_t<Fun, Args...>;
 
+template<typename T>
+constexpr bool isConst = std::is_const_v<std::remove_reference_t<T>>;
+
 template<typename T, typename U>
 constexpr bool isConvertible = std::is_convertible<PlainType<T>, U>::value;
 

--- a/autodiff/forward/utils/gradient.hpp
+++ b/autodiff/forward/utils/gradient.hpp
@@ -66,10 +66,12 @@ constexpr auto ForEachWrtVar(const Wrt<Vars...>& wrt, Function&& f)
     auto i = 0; // the current index of the variable in the wrt list
     ForEach(wrt.args, [&](auto& item) constexpr
     {
-        if constexpr (isVector<decltype(item)>) {
+        using T = decltype(item);
+        static_assert(isVector<T> || Order<T> > 0, "Expecting a wrt list with either vectors or individual autodiff numbers.");
+        if constexpr (isVector<T>) {
             for(auto j = 0; j < item.size(); ++j)
                 // call given f with current index and variable from item (a vector)
-                if constexpr (detail::has_operator_bracket<decltype(item)>()) {
+                if constexpr (detail::has_operator_bracket<T>()) {
                     f(i++, item[j]);
                 } else {
                     f(i++, item(j));
@@ -94,6 +96,7 @@ void gradient(const Fun& f, const Wrt<Vars...>& wrt, const At<Args...>& at, Y& u
 
     ForEachWrtVar(wrt, [&](auto&& i, auto&& xi) constexpr
     {
+        static_assert(!isConst<decltype(xi)>, "Expecting non-const autodiff numbers in wrt list because these need to be seeded, and thus altered!");
         u = eval(f, at, detail::wrt(xi)); // evaluate u with xi seeded so that du/dxi is also computed
         g[i] = derivative<1>(u);
     });
@@ -131,6 +134,7 @@ void jacobian(const Fun& f, const Wrt<Vars...>& wrt, const At<Args...>& at, Y& F
     size_t m = 0;
 
     ForEachWrtVar(wrt, [&](auto&& i, auto&& xi) constexpr {
+        static_assert(!isConst<decltype(xi)>, "Expecting non-const autodiff numbers in wrt list because these need to be seeded, and thus altered!");
         F = eval(f, at, detail::wrt(xi)); // evaluate F with xi seeded so that dF/dxi is also computed
         if(m == 0) { m = F.size(); J.resize(m, n); };
         for(size_t row = 0; row < m; ++row)
@@ -180,6 +184,7 @@ void hessian(const Fun& f, const Wrt<Vars...>& wrt, const At<Args...>& at, U& u,
     ForEachWrtVar(wrt, [&](auto&& i, auto&& xi) constexpr {
         ForEachWrtVar(wrt, [&](auto&& j, auto&& xj) constexpr
         {
+            static_assert(!isConst<decltype(xi)> && !isConst<decltype(xj)>, "Expecting non-const autodiff numbers in wrt list because these need to be seeded, and thus altered!");
             if(j >= i) { // this take advantage of the fact the Hessian matrix is symmetric
                 u = eval(f, at, detail::wrt(xi, xj)); // evaluate u with xi and xj seeded to produce u0, du/dxi, d2u/dxidxj
                 g[i] = derivative<1>(u);              // get du/dxi from u

--- a/autodiff/reverse/var/eigen.hpp
+++ b/autodiff/reverse/var/eigen.hpp
@@ -75,6 +75,35 @@ struct ScalarBinaryOpTraits<T, autodiff::Variable<T>, BinOp>
     typedef autodiff::Variable<T> ReturnType;
 };
 
+template<typename T>
+struct NumTraits<autodiff::detail::ExprPtr<T>> : NumTraits<T> // permits to get the epsilon, dummy_precision, lowest, highest functions
+{
+    typedef autodiff::Variable<T> Real;
+    typedef autodiff::Variable<T> NonInteger;
+    typedef autodiff::Variable<T> Nested;
+    enum
+    {
+        IsComplex = 0,
+        IsInteger = 0,
+        IsSigned = 1,
+        RequireInitialization = 1,
+        ReadCost = 1,
+        AddCost = 3,
+        MulCost = 3
+    };
+};
+
+template<typename T, typename BinOp>
+struct ScalarBinaryOpTraits<autodiff::detail::ExprPtr<T>, T, BinOp>
+{
+    typedef autodiff::Variable<T> ReturnType;
+};
+
+template<typename T, typename BinOp>
+struct ScalarBinaryOpTraits<T, autodiff::detail::ExprPtr<T>, BinOp>
+{
+    typedef autodiff::Variable<T> ReturnType;
+};
 
 } // namespace Eigen
 

--- a/tests/forward/dual/eigen.test.cpp
+++ b/tests/forward/dual/eigen.test.cpp
@@ -171,7 +171,6 @@ TEST_CASE("testing autodiff::dual (with eigen)", "[forward][dual][eigen]")
     {
         SECTION("testing gradient derivatives")
         {
-            // Testing complex function involving sin and cos
             auto f = [](const VectorXdual& x) -> dual
             {
                 return 0.5 * ( x.array() * x.array() ).sum();
@@ -189,7 +188,6 @@ TEST_CASE("testing autodiff::dual (with eigen)", "[forward][dual][eigen]")
 
         SECTION("testing gradient derivatives of only the last two variables")
         {
-            // Testing complex function involving sin and cos
             auto f = [](const VectorXdual& x) -> dual
             {
                 return 0.5 * ( x.array() * x.array() ).sum();
@@ -206,7 +204,6 @@ TEST_CASE("testing autodiff::dual (with eigen)", "[forward][dual][eigen]")
 
         SECTION("testing jacobian derivatives")
         {
-            // Testing complex function involving sin and cos
             auto f = [](const VectorXdual& x) -> VectorXdual
             {
                 return x / x.array().sum();
@@ -226,7 +223,6 @@ TEST_CASE("testing autodiff::dual (with eigen)", "[forward][dual][eigen]")
 
         SECTION("testing jacobian derivatives of only the last two variables")
         {
-            // Testing complex function involving sin and cos
             auto f = [](const VectorXdual& x) -> VectorXdual
             {
                 return x / x.array().sum();
@@ -267,7 +263,6 @@ TEST_CASE("testing autodiff::dual (with eigen)", "[forward][dual][eigen]")
 
         SECTION("test gradient size with respect to few arguments")
         {
-            // Testing complex function involving sin and cos
             auto f = [](const VectorXdual& x, dual y, const VectorXdual& z) -> dual
             {
                 return 0.5 * (( x.array() * x.array() ).sum() + y * y + (z.array() * z.array()).sum());
@@ -397,7 +392,6 @@ TEST_CASE("testing autodiff::dual (with eigen)", "[forward][dual][eigen]")
 
         SECTION("testing gradient derivatives")
         {
-            // Testing complex function involving sin and cos
             auto f = [](const VectorXdual2nd& x) -> dual2nd
             {
                 return 0.5 * ( x.array() * x.array() ).sum();
@@ -415,7 +409,6 @@ TEST_CASE("testing autodiff::dual (with eigen)", "[forward][dual][eigen]")
 
         SECTION("testing jacobian derivatives")
         {
-            // Testing complex function involving sin and cos
             auto f = [](const VectorXdual2nd& x) -> VectorXdual2nd
             {
                 return x / x.array().sum();
@@ -435,7 +428,6 @@ TEST_CASE("testing autodiff::dual (with eigen)", "[forward][dual][eigen]")
 
         SECTION("testing hessian derivatives")
         {
-            // Testing complex function involving sin and cos
             auto f = [](const VectorXdual2nd& x) -> dual2nd
             {
                 return 0.5 * ( x.array() * x.array() ).sum();
@@ -470,7 +462,6 @@ TEST_CASE("testing autodiff::dual (with eigen)", "[forward][dual][eigen]")
 
         SECTION("testing gradient derivatives")
         {
-            // Testing complex function involving sin and cos
             auto f = [](const VectorXdual3rd& x) -> dual3rd
             {
                 return 0.5 * ( x.array() * x.array() ).sum();
@@ -488,7 +479,6 @@ TEST_CASE("testing autodiff::dual (with eigen)", "[forward][dual][eigen]")
 
         SECTION("testing jacobian derivatives")
         {
-            // Testing complex function involving sin and cos
             auto f = [](const VectorXdual3rd& x) -> VectorXdual3rd
             {
                 return x / x.array().sum();
@@ -508,7 +498,6 @@ TEST_CASE("testing autodiff::dual (with eigen)", "[forward][dual][eigen]")
 
         SECTION("testing hessian derivatives")
         {
-            // Testing complex function involving sin and cos
             auto f = [](const VectorXdual3rd& x) -> dual3rd
             {
                 return 0.5 * ( x.array() * x.array() ).sum();
@@ -522,6 +511,50 @@ TEST_CASE("testing autodiff::dual (with eigen)", "[forward][dual][eigen]")
             for(auto i = 0; i < 3; ++i)
                 for(auto j = 0; j < 3; ++j)
                     CHECK( H(i, j) == approx(((i == j) ? 1.0 : 0.0)) );
+        }
+    }
+
+    SECTION("using Eigen::Map")
+    {
+        SECTION("testing gradient derivatives")
+        {
+            auto f = [](const VectorXdual& x) -> dual
+            {
+                return 0.5 * ( x.array() * x.array() ).sum();
+            };
+
+            VectorXdual vec(3);
+            vec << 1.0, 2.0, 3.0;
+
+            auto x = Eigen::Map<VectorXdual>(vec.data(), vec.size());
+
+            VectorXd g = gradient(f, wrt(x), at(x));
+
+            CHECK( g[0] == approx(x[0]) );
+            CHECK( g[1] == approx(x[1]) );
+            CHECK( g[2] == approx(x[2]) );
+        }
+
+        SECTION("testing jacobian derivatives")
+        {
+            auto f = [](const VectorXdual& x) -> VectorXdual
+            {
+                return x / x.array().sum();
+            };
+
+
+            VectorXdual vec(3);
+            vec << 0.5, 0.2, 0.3;
+
+            auto x = Eigen::Map<VectorXdual>(vec.data(), vec.size());
+
+            VectorXdual F;
+
+            const MatrixXd J = jacobian(f, wrt(x), at(x), F);
+
+            for(auto i = 0; i < 3; ++i)
+                for(auto j = 0; j < 3; ++j)
+                    CHECK( J(i, j) == approx(-F[i] + ((i == j) ? 1.0 : 0.0)) );
         }
     }
 }

--- a/tests/forward/real/eigen.test.cpp
+++ b/tests/forward/real/eigen.test.cpp
@@ -163,4 +163,86 @@ TEST_CASE("testing autodiff::real (with eigen)", "[forward][real][eigen]")
         CHECK( derivative<1>(b[0]) == approx(18.0) );
         CHECK( derivative<1>(b[1]) == approx(50.0) );
     }
+
+    SECTION("testing gradient derivatives")
+    {
+        SECTION("using VectorXreal")
+        {
+            auto f = [](const VectorXreal& x) -> real
+            {
+                return 0.5 * ( x.array() * x.array() ).sum();
+            };
+
+            VectorXreal x(3);
+            x << 1.0, 2.0, 3.0;
+
+            VectorXd g = gradient(f, wrt(x), at(x));
+
+            CHECK( g[0] == approx(x[0]) );
+            CHECK( g[1] == approx(x[1]) );
+            CHECK( g[2] == approx(x[2]) );
+        }
+
+        SECTION("using Eigen::Map<VectorXreal>")
+        {
+            auto f = [](const VectorXreal& x) -> real
+            {
+                return 0.5 * ( x.array() * x.array() ).sum();
+            };
+
+            VectorXreal vec(3);
+            vec << 1.0, 2.0, 3.0;
+
+            auto x = Eigen::Map<VectorXreal>(vec.data(), vec.size());
+
+            VectorXd g = gradient(f, wrt(x), at(x));
+
+            CHECK( g[0] == approx(x[0]) );
+            CHECK( g[1] == approx(x[1]) );
+            CHECK( g[2] == approx(x[2]) );
+        }
+    }
+
+    SECTION("testing jacobian derivatives")
+    {
+        SECTION("using VectorXreal")
+        {
+            auto f = [](const VectorXreal& x) -> VectorXreal
+            {
+                return x / x.array().sum();
+            };
+
+            VectorXreal vec(3);
+            vec << 0.5, 0.2, 0.3;
+
+            auto x = Eigen::Map<VectorXreal>(vec.data(), vec.size());
+
+            VectorXreal F;
+
+            const MatrixXd J = jacobian(f, wrt(x), at(x), F);
+
+            for(auto i = 0; i < 3; ++i)
+                for(auto j = 0; j < 3; ++j)
+                    CHECK( J(i, j) == approx(-F[i] + ((i == j) ? 1.0 : 0.0)) );
+        }
+
+        SECTION("using Eigen::Map<VectorXreal>")
+        {
+            auto f = [](const VectorXreal& x) -> VectorXreal
+            {
+                return x / x.array().sum();
+            };
+
+            VectorXreal x(3);
+            x << 0.5, 0.2, 0.3;
+
+            VectorXreal F;
+
+            const MatrixXd J = jacobian(f, wrt(x), at(x), F);
+
+            for(auto i = 0; i < 3; ++i)
+                for(auto j = 0; j < 3; ++j)
+                    CHECK( J(i, j) == approx(-F[i] + ((i == j) ? 1.0 : 0.0)) );
+        }
+    }
 }


### PR DESCRIPTION
This PR introduces support for the use of `Eigen::Map` when using `autodiff::gradient`, `autodiff::jacobian`, `autodiff::hessian`.

It also introduces some static asserts to ensure that entries in the `wrt` lists are non-const.

Fixes #194 