### PR TITLE
Documentation: updated reverse mode; included dependencies

### DIFF
--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -141,11 +141,7 @@ auto [ux, uy, uz] = derivatives(u, wrt(x, y, z));
 
 The function `autodiff::derivatives` will traverse the expression tree stored
 in variable `u` and compute all its derivatives with respect to the input
-variables *(x, y, z)*, which are then stored in the object `dud`. The
-derivative of `u` with respect to input variable `x` (i.e., *∂u/∂x*) can then
-be extracted from `dud` using `dud(x)`. The operations `dud(x)`, `dud(y)`,
-`dud(z)` involve no computations! Just extraction of derivatives previously
-computed with a call to function `autodiff::derivatives`.
+variables *(x, y, z)*.
 
 ## Get in touch!
 

--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -13,8 +13,8 @@
 techniques to enable automatic computation of derivatives in an efficient, easy,
 and intuitive way.
 
-We welcome you to use {{autodiff}} and recommend us any improvements you think
-it is necessary. You may want to do so by chatting with us on our [Gitter
+We welcome you to use {{autodiff}} and recommend to us any improvements you think
+are necessary. You may want to do so by chatting with us on our [Gitter
 Community Channel][gitter] and/or by making proposals by creating a [GitHub
 issue][issues].
 

--- a/docs/website/installation.md
+++ b/docs/website/installation.md
@@ -34,8 +34,13 @@ and follow the instructions below to build {{autodiff}} from source.
 ## Installation using CMake
 
 If you have `cmake` installed in your system, you can then not only install
-{{autodiff}} but also build its examples and tests. First, you'll need to
-download it by either git cloning its [GitHub repository][github]:
+{{autodiff}} but also build its examples and tests.
+
+First, you'll need to make sure that the following dependencies are met:
+* [Catch2] in version 3, currently on the `devel` branch of the Catch2 repository
+* [pybind11]
+
+Then, you can start to download {{autodiff}} by either git cloning its [GitHub repository][github]:
 
 ~~~
 git clone https://github.com/autodiff/autodiff
@@ -44,7 +49,7 @@ git clone https://github.com/autodiff/autodiff
 or by [clicking here][zip] to start the download of a zip file, which you
 should extract to a directory of your choice.
 
-Then, execute the following steps (assuming you are in the root of the source code directory of {{autodiff}}!):
+Next, execute the following steps (assuming you are in the root of the source code directory of {{autodiff}}!):
 
 ~~~
 mkdir .build && cd .build
@@ -122,3 +127,5 @@ installation improvements in the Gitter channel.
 [zip]: https://github.com/autodiff/autodiff/archive/master.zip
 [issues]: https://github.com/autodiff/autodiff/issues/new
 [conda-devenv]: https://conda-devenv.readthedocs.io/en/latest/
+[Catch2]: https://github.com/catchorg/Catch2
+[pybind11]: https://github.com/pybind/pybind11


### PR DESCRIPTION
The documentation was outdated in one place and I added the dependencies which I needed to install to get it to compile. There might be more dependencies which were already pre-installed on my system.