### PR TITLE
Unit tests + cleanup of `real.hpp`

### DIFF
--- a/autodiff/forward/real/eigen.hpp
+++ b/autodiff/forward/real/eigen.hpp
@@ -33,9 +33,9 @@
 #include <Eigen/Core>
 
 // autodiff includes
+#include <autodiff/common/eigen.hpp>
 #include <autodiff/forward/real.hpp>
 #include <autodiff/forward/utils/gradient.hpp>
-#include <autodiff/common/eigen.hpp>
 
 //------------------------------------------------------------------------------
 // SUPPORT FOR EIGEN MATRICES AND VECTORS OF REAL

--- a/autodiff/forward/real/real.hpp
+++ b/autodiff/forward/real/real.hpp
@@ -40,8 +40,8 @@
 
 // autodiff includes
 #include <autodiff/common/binomialcoefficient.hpp>
-#include <autodiff/common/numbertraits.hpp>
 #include <autodiff/common/meta.hpp>
+#include <autodiff/common/numbertraits.hpp>
 
 namespace autodiff {
 namespace detail {
@@ -50,17 +50,18 @@ namespace detail {
 template<size_t N, typename T>
 class Real
 {
-private:
+  private:
     // Ensure type T is a numeric type
     static_assert(isArithmetic<T>);
 
     /// The value and derivatives of the number up to order *N*.
     std::array<T, N + 1> m_data = {};
 
-public:
+  public:
     /// Construct a default Real number of order *N* and type *T*.
     constexpr Real()
-    {}
+    {
+    }
 
     /// Construct a Real number with given data.
     constexpr Real(const T& value)
@@ -70,8 +71,9 @@ public:
 
     /// Construct a Real number with given data.
     constexpr Real(const std::array<T, N + 1>& data)
-    : m_data(data)
-    {}
+        : m_data(data)
+    {
+    }
 
     /// Construct a Real number with given data.
     template<size_t M, typename U, Requires<isArithmetic<U>> = true>
@@ -189,10 +191,16 @@ public:
     /// Convert this Real number into a value of type @p U.
 #if defined(AUTODIFF_ENABLE_IMPLICIT_CONVERSION_REAL) || defined(AUTODIFF_ENABLE_IMPLICIT_CONVERSION)
     template<typename U, Requires<isArithmetic<U>> = true>
-    constexpr operator U() const { return static_cast<U>(m_data[0]); }
+    constexpr operator U() const
+    {
+        return static_cast<U>(m_data[0]);
+    }
 #else
     template<typename U, Requires<isArithmetic<U>> = true>
-    constexpr explicit operator U() const { return static_cast<U>(m_data[0]); }
+    constexpr explicit operator U() const
+    {
+        return static_cast<U>(m_data[0]);
+    }
 #endif
 };
 
@@ -207,8 +215,8 @@ using std::acos;
 using std::acosh;
 using std::asin;
 using std::asinh;
-using std::atan2;
 using std::atan;
+using std::atan2;
 using std::atanh;
 using std::cbrt;
 using std::cos;
@@ -232,10 +240,16 @@ using std::tanh;
 //=====================================================================================================================
 
 template<typename T>
-struct isRealAux { constexpr static bool value = false; };
+struct isRealAux
+{
+    constexpr static bool value = false;
+};
 
 template<size_t N, typename T>
-struct isRealAux<Real<N, T>> { constexpr static bool value = true; };
+struct isRealAux<Real<N, T>>
+{
+    constexpr static bool value = true;
+};
 
 template<typename T>
 constexpr bool isReal = isRealAux<PlainType<T>>::value;
@@ -389,9 +403,9 @@ constexpr auto log(const Real<N, T>& x)
     logx[0] = log(x[0]);
     For<1, N + 1>([&](auto i) constexpr {
         logx[i] = x[i] - Sum<1, i>([&](auto j) constexpr {
-            constexpr auto c = BinomialCoefficient<i.index - 1, j.index - 1>;
-            return c * x[i - j] * logx[j];
-        });
+                      constexpr auto c = BinomialCoefficient<i.index - 1, j.index - 1>;
+                      return c * x[i - j] * logx[j];
+                  });
         logx[i] /= x[0];
     });
     return logx;
@@ -412,22 +426,22 @@ constexpr auto sqrt(const Real<N, T>& x)
     Real<N, T> res;
     res[0] = sqrt(x[0]);
 
-    if constexpr (N > 0)
-    {
+    if constexpr(N > 0) {
         // assert(x[0] != 0 && "autodiff::sqrt(x) has undefined derivatives when x = 0");
-        if(x[0] == 0) return res;
+        if(x[0] == 0)
+            return res;
         Real<N, T> a;
         For<1, N + 1>([&](auto i) constexpr {
             a[i] = x[i] - Sum<1, i>([&](auto j) constexpr {
-                constexpr auto c = BinomialCoefficient<i.index - 1, j.index - 1>;
-                return c * x[i - j] * a[j];
-            });
+                       constexpr auto c = BinomialCoefficient<i.index - 1, j.index - 1>;
+                       return c * x[i - j] * a[j];
+                   });
             a[i] /= x[0];
 
             res[i] = 0.5 * Sum<0, i>([&](auto j) constexpr {
-                constexpr auto c = BinomialCoefficient<i.index - 1, j.index>;
-                return c * a[i - j] * res[j];
-            });
+                         constexpr auto c = BinomialCoefficient<i.index - 1, j.index>;
+                         return c * a[i - j] * res[j];
+                     });
         });
     }
     return res;
@@ -439,22 +453,22 @@ constexpr auto cbrt(const Real<N, T>& x)
     Real<N, T> res;
     res[0] = cbrt(x[0]);
 
-    if constexpr (N > 0)
-    {
+    if constexpr(N > 0) {
         // assert(x[0] != 0 && "autodiff::cbrt(x) has undefined derivatives when x = 0");
-        if(x[0] == 0) return res;
+        if(x[0] == 0)
+            return res;
         Real<N, T> a;
         For<1, N + 1>([&](auto i) constexpr {
             a[i] = x[i] - Sum<1, i>([&](auto j) constexpr {
-                constexpr auto c = BinomialCoefficient<i.index - 1, j.index - 1>;
-                return c * x[i - j] * a[j];
-            });
+                       constexpr auto c = BinomialCoefficient<i.index - 1, j.index - 1>;
+                       return c * x[i - j] * a[j];
+                   });
             a[i] /= x[0];
 
-            res[i] = (1.0/3.0) * Sum<0, i>([&](auto j) constexpr {
-                constexpr auto c = BinomialCoefficient<i.index - 1, j.index>;
-                return c * a[i - j] * res[j];
-            });
+            res[i] = (1.0 / 3.0) * Sum<0, i>([&](auto j) constexpr {
+                         constexpr auto c = BinomialCoefficient<i.index - 1, j.index>;
+                         return c * a[i - j] * res[j];
+                     });
         });
     }
     return res;
@@ -465,10 +479,10 @@ constexpr auto pow(const Real<N, T>& x, const Real<N, T>& y)
 {
     Real<N, T> res;
     res[0] = pow(x[0], y[0]);
-    if constexpr (N > 0)
-    {
+    if constexpr(N > 0) {
         // assert(x[0] != 0 && "autodiff::pow(x, y) has undefined derivatives when x = 0");
-        if(x[0] == 0) return res;
+        if(x[0] == 0)
+            return res;
         Real<N, T> lnx = log(x);
         Real<N, T> a;
         For<1, N + 1>([&](auto i) constexpr {
@@ -491,10 +505,10 @@ constexpr auto pow(const Real<N, T>& x, const U& c)
 {
     Real<N, T> res;
     res[0] = pow(x[0], static_cast<T>(c));
-    if constexpr (N > 0)
-    {
+    if constexpr(N > 0) {
         // assert(x[0] != 0 && "autodiff::pow(x, y) has undefined derivatives when x = 0");
-        if(x[0] == 0) return res;
+        if(x[0] == 0)
+            return res;
         Real<N, T> a = c * log(x);
         For<1, N + 1>([&](auto i) constexpr {
             res[i] = Sum<0, i>([&](auto j) constexpr {
@@ -511,10 +525,10 @@ constexpr auto pow(const U& c, const Real<N, T>& y)
 {
     Real<N, T> res;
     res[0] = pow(static_cast<T>(c), y[0]);
-    if constexpr (N > 0)
-    {
+    if constexpr(N > 0) {
         // assert(c != 0 && "autodiff::pow(x, y) has undefined derivatives when x = 0");
-        if(c == 0) return res;
+        if(c == 0)
+            return res;
         Real<N, T> a = y * log(c);
         For<1, N + 1>([&](auto i) constexpr {
             res[i] = Sum<0, i>([&](auto j) constexpr {
@@ -574,10 +588,9 @@ auto tan(const Real<N, T>& x)
     Real<N, T> tanx;
     tanx[0] = tan(x[0]);
 
-    if constexpr (N > 0)
-    {
+    if constexpr(N > 0) {
         Real<N, T> aux;
-        aux[0] = 1 + tanx[0]*tanx[0];
+        aux[0] = 1 + tanx[0] * tanx[0];
 
         For<1, N + 1>([&](auto i) constexpr {
             tanx[i] = Sum<0, i>([&](auto j) constexpr {
@@ -585,10 +598,10 @@ auto tan(const Real<N, T>& x)
                 return c * x[i - j] * aux[j];
             });
 
-            aux[i] = 2*Sum<0, i>([&](auto j) constexpr {
-                constexpr auto c = BinomialCoefficient<i.index - 1, j.index>;
-                return c * tanx[i - j] * tanx[j];
-            });
+            aux[i] = 2 * Sum<0, i>([&](auto j) constexpr {
+                         constexpr auto c = BinomialCoefficient<i.index - 1, j.index>;
+                         return c * tanx[i - j] * tanx[j];
+                     });
         });
     }
 
@@ -600,15 +613,14 @@ constexpr auto asin(const Real<N, T>& x)
 {
     Real<N, T> res;
     res[0] = asin(x[0]);
-    if constexpr (N > 0)
-    {
+    if constexpr(N > 0) {
         assert(x[0] < 1.0 && "autodiff::asin(x) has undefined derivative when |x| >= 1");
         Real<N - 1, T> xprime;
         For<1, N + 1>([&](auto i) constexpr {
             xprime[i - 1] = x[i];
         });
         Real<N - 1, T> aux(x);
-        aux = xprime/sqrt(1 - aux*aux);
+        aux = xprime / sqrt(1 - aux * aux);
         For<1, N + 1>([&](auto i) constexpr {
             res[i] = aux[i - 1];
         });
@@ -621,15 +633,14 @@ constexpr auto acos(const Real<N, T>& x)
 {
     Real<N, T> res;
     res[0] = acos(x[0]);
-    if constexpr (N > 0)
-    {
+    if constexpr(N > 0) {
         assert(x[0] < 1.0 && "autodiff::acos(x) has undefined derivative when |x| >= 1");
         Real<N - 1, T> xprime;
         For<1, N + 1>([&](auto i) constexpr {
             xprime[i - 1] = x[i];
         });
         Real<N - 1, T> aux(x);
-        aux = -xprime/sqrt(1 - aux*aux);
+        aux = -xprime / sqrt(1 - aux * aux);
         For<1, N + 1>([&](auto i) constexpr {
             res[i] = aux[i - 1];
         });
@@ -642,14 +653,13 @@ constexpr auto atan(const Real<N, T>& x)
 {
     Real<N, T> res;
     res[0] = atan(x[0]);
-    if constexpr (N > 0)
-    {
+    if constexpr(N > 0) {
         Real<N - 1, T> xprime;
         For<1, N + 1>([&](auto i) constexpr {
             xprime[i - 1] = x[i];
         });
         Real<N - 1, T> aux(x);
-        aux = xprime/(1 + aux*aux);
+        aux = xprime / (1 + aux * aux);
         For<1, N + 1>([&](auto i) constexpr {
             res[i] = aux[i - 1];
         });
@@ -753,18 +763,16 @@ auto cosh(const Real<N, T>& x)
     return std::get<1>(sinhcosh(x));
 }
 
-
 template<size_t N, typename T>
 auto tanh(const Real<N, T>& x)
 {
     Real<N, T> tanhx;
     tanhx[0] = tanh(x[0]);
 
-    if constexpr (N > 0)
-    {
+    if constexpr(N > 0) {
         Real<N, T> aux;
 
-        aux[0] = 1 - tanhx[0]*tanhx[0];
+        aux[0] = 1 - tanhx[0] * tanhx[0];
 
         For<1, N + 1>([&](auto i) constexpr {
             tanhx[i] = Sum<0, i>([&](auto j) constexpr {
@@ -772,7 +780,7 @@ auto tanh(const Real<N, T>& x)
                 return c * x[i - j] * aux[j];
             });
 
-            aux[i] = -2*Sum<0, i>([&](auto j) constexpr {
+            aux[i] = -2 * Sum<0, i>([&](auto j) constexpr {
                 constexpr auto c = BinomialCoefficient<i.index - 1, j.index>;
                 return c * tanhx[i - j] * tanhx[j];
             });
@@ -787,10 +795,9 @@ constexpr auto asinh(const Real<N, T>& x)
 {
     Real<N, T> res;
     res[0] = asinh(x[0]);
-    if constexpr (N > 0)
-    {
+    if constexpr(N > 0) {
         Real<N - 1, T> aux(x);
-        aux = 1/sqrt(aux*aux + 1);
+        aux = 1 / sqrt(aux * aux + 1);
         For<1, N + 1>([&](auto i) constexpr {
             res[i] = aux[i - 1];
         });
@@ -803,11 +810,10 @@ constexpr auto acosh(const Real<N, T>& x)
 {
     Real<N, T> res;
     res[0] = acosh(x[0]);
-    if constexpr (N > 0)
-    {
+    if constexpr(N > 0) {
         assert(x[0] > 1.0 && "autodiff::acosh(x) has undefined derivative when |x| <= 1");
         Real<N - 1, T> aux(x);
-        aux = 1/sqrt(aux*aux - 1);
+        aux = 1 / sqrt(aux * aux - 1);
         For<1, N + 1>([&](auto i) constexpr {
             res[i] = aux[i - 1];
         });
@@ -820,11 +826,10 @@ constexpr auto atanh(const Real<N, T>& x)
 {
     Real<N, T> res;
     res[0] = atanh(x[0]);
-    if constexpr (N > 0)
-    {
+    if constexpr(N > 0) {
         assert(x[0] < 1.0 && "autodiff::atanh(x) has undefined derivative when |x| >= 1");
         Real<N - 1, T> aux(x);
-        aux = 1/(1 - aux*aux);
+        aux = 1 / (1 - aux * aux);
         For<1, N + 1>([&](auto i) constexpr {
             res[i] = aux[i - 1];
         });
@@ -843,10 +848,10 @@ constexpr auto abs(const Real<N, T>& x)
 {
     Real<N, T> res;
     res[0] = std::abs(x[0]);
-    if constexpr (N > 0)
-    {
+    if constexpr(N > 0) {
         // assert(x[0] != 0 && "autodiff::abs(x) has undefined derivatives when x = 0");
-        if(x[0] == 0) return res;
+        if(x[0] == 0)
+            return res;
         const T s = std::copysign(1.0, x[0]);
         For<1, N + 1>([&](auto i) constexpr {
             res[i] = s * x[i];
@@ -931,25 +936,93 @@ bool operator==(const Real<N, T>& x, const Real<N, T>& y)
     return res;
 }
 
-template<size_t N, typename T> bool operator!=(const Real<N, T>& x, const Real<N, T>& y) { return !(x == y); }
-template<size_t N, typename T> bool operator< (const Real<N, T>& x, const Real<N, T>& y) { return x[0] <  y[0]; }
-template<size_t N, typename T> bool operator> (const Real<N, T>& x, const Real<N, T>& y) { return x[0] >  y[0]; }
-template<size_t N, typename T> bool operator<=(const Real<N, T>& x, const Real<N, T>& y) { return x[0] <= y[0]; }
-template<size_t N, typename T> bool operator>=(const Real<N, T>& x, const Real<N, T>& y) { return x[0] >= y[0]; }
+template<size_t N, typename T>
+bool operator!=(const Real<N, T>& x, const Real<N, T>& y)
+{
+    return !(x == y);
+}
+template<size_t N, typename T>
+bool operator<(const Real<N, T>& x, const Real<N, T>& y)
+{
+    return x[0] < y[0];
+}
+template<size_t N, typename T>
+bool operator>(const Real<N, T>& x, const Real<N, T>& y)
+{
+    return x[0] > y[0];
+}
+template<size_t N, typename T>
+bool operator<=(const Real<N, T>& x, const Real<N, T>& y)
+{
+    return x[0] <= y[0];
+}
+template<size_t N, typename T>
+bool operator>=(const Real<N, T>& x, const Real<N, T>& y)
+{
+    return x[0] >= y[0];
+}
 
-template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true> bool operator==(const Real<N, T>& x, const U& y) { return x[0] == y; }
-template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true> bool operator!=(const Real<N, T>& x, const U& y) { return x[0] != y; }
-template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true> bool operator< (const Real<N, T>& x, const U& y) { return x[0] <  y; }
-template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true> bool operator> (const Real<N, T>& x, const U& y) { return x[0] >  y; }
-template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true> bool operator<=(const Real<N, T>& x, const U& y) { return x[0] <= y; }
-template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true> bool operator>=(const Real<N, T>& x, const U& y) { return x[0] >= y; }
+template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
+bool operator==(const Real<N, T>& x, const U& y)
+{
+    return x[0] == y;
+}
+template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
+bool operator!=(const Real<N, T>& x, const U& y)
+{
+    return x[0] != y;
+}
+template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
+bool operator<(const Real<N, T>& x, const U& y)
+{
+    return x[0] < y;
+}
+template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
+bool operator>(const Real<N, T>& x, const U& y)
+{
+    return x[0] > y;
+}
+template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
+bool operator<=(const Real<N, T>& x, const U& y)
+{
+    return x[0] <= y;
+}
+template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
+bool operator>=(const Real<N, T>& x, const U& y)
+{
+    return x[0] >= y;
+}
 
-template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true> bool operator==(const U& x, const Real<N, T>& y) { return x == y[0]; }
-template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true> bool operator!=(const U& x, const Real<N, T>& y) { return x != y[0]; }
-template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true> bool operator< (const U& x, const Real<N, T>& y) { return x <  y[0]; }
-template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true> bool operator> (const U& x, const Real<N, T>& y) { return x >  y[0]; }
-template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true> bool operator<=(const U& x, const Real<N, T>& y) { return x <= y[0]; }
-template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true> bool operator>=(const U& x, const Real<N, T>& y) { return x >= y[0]; }
+template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
+bool operator==(const U& x, const Real<N, T>& y)
+{
+    return x == y[0];
+}
+template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
+bool operator!=(const U& x, const Real<N, T>& y)
+{
+    return x != y[0];
+}
+template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
+bool operator<(const U& x, const Real<N, T>& y)
+{
+    return x < y[0];
+}
+template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
+bool operator>(const U& x, const Real<N, T>& y)
+{
+    return x > y[0];
+}
+template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
+bool operator<=(const U& x, const Real<N, T>& y)
+{
+    return x <= y[0];
+}
+template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
+bool operator>=(const U& x, const Real<N, T>& y)
+{
+    return x >= y[0];
+}
 
 //=====================================================================================================================
 //
@@ -961,10 +1034,10 @@ template<size_t order, size_t N, typename T, typename U>
 auto seed(Real<N, T>& real, U&& seedval)
 {
     static_assert(order == 1,
-        "Real<N, T> is optimized for higher-order **directional** derivatives. "
-        "You're possibly trying to use it for computing higher-order **cross** derivatives "
-        "(e.g., `derivative(f, wrt(x, x, y), at(x, y))`) which is not supported by Real<N, T>. "
-        "Use Dual<T, G> instead (e.g., `using dual4th = HigherOrderDual<4>;`)");
+                  "Real<N, T> is optimized for higher-order **directional** derivatives. "
+                  "You're possibly trying to use it for computing higher-order **cross** derivatives "
+                  "(e.g., `derivative(f, wrt(x, x, y), at(x, y))`) which is not supported by Real<N, T>. "
+                  "Use Dual<T, G> instead (e.g., `using dual4th = HigherOrderDual<4>;`)");
     real[order] = static_cast<T>(seedval);
 }
 
@@ -1012,10 +1085,10 @@ struct NumberTraits<Real<N, T>>
 //
 //=====================================================================================================================
 
-using detail::Real;
-using detail::val;
 using detail::derivative;
+using detail::Real;
 using detail::repr;
+using detail::val;
 
 using real0th = Real<0, double>;
 using real1st = Real<1, double>;

--- a/autodiff/forward/real/real.hpp
+++ b/autodiff/forward/real/real.hpp
@@ -210,7 +210,7 @@ class Real
 #endif
 
     template<size_t M, typename U>
-    friend bool operator==(const Real<M, U>& x, const Real<M, U>& y);
+    friend constexpr bool operator==(const Real<M, U>& x, const Real<M, U>& y);
 };
 
 //=====================================================================================================================
@@ -915,95 +915,98 @@ auto repr(const Real<N, T>& x)
 //=====================================================================================================================
 
 template<size_t N, typename T>
-bool operator==(const Real<N, T>& x, const Real<N, T>& y)
+constexpr bool operator==(const Real<N, T>& x, const Real<N, T>& y)
 {
-    return std::equal(x.m_data.begin(), x.m_data.end(), y.m_data.begin(), y.m_data.end());
+    for(int i = 0; i < N + 1; ++i)
+        if(x[i] != y[i])
+            return false;
+    return true;
 }
 
 template<size_t N, typename T>
-bool operator!=(const Real<N, T>& x, const Real<N, T>& y)
+constexpr bool operator!=(const Real<N, T>& x, const Real<N, T>& y)
 {
     return !(x == y);
 }
 template<size_t N, typename T>
-bool operator<(const Real<N, T>& x, const Real<N, T>& y)
+constexpr bool operator<(const Real<N, T>& x, const Real<N, T>& y)
 {
     return x[0] < y[0];
 }
 template<size_t N, typename T>
-bool operator>(const Real<N, T>& x, const Real<N, T>& y)
+constexpr bool operator>(const Real<N, T>& x, const Real<N, T>& y)
 {
     return x[0] > y[0];
 }
 template<size_t N, typename T>
-bool operator<=(const Real<N, T>& x, const Real<N, T>& y)
+constexpr bool operator<=(const Real<N, T>& x, const Real<N, T>& y)
 {
     return x[0] <= y[0];
 }
 template<size_t N, typename T>
-bool operator>=(const Real<N, T>& x, const Real<N, T>& y)
+constexpr bool operator>=(const Real<N, T>& x, const Real<N, T>& y)
 {
     return x[0] >= y[0];
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator==(const Real<N, T>& x, const U y)
+constexpr bool operator==(const Real<N, T>& x, const U y)
 {
     return x[0] == y;
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator!=(const Real<N, T>& x, const U y)
+constexpr bool operator!=(const Real<N, T>& x, const U y)
 {
     return x[0] != y;
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator<(const Real<N, T>& x, const U y)
+constexpr bool operator<(const Real<N, T>& x, const U y)
 {
     return x[0] < y;
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator>(const Real<N, T>& x, const U y)
+constexpr bool operator>(const Real<N, T>& x, const U y)
 {
     return x[0] > y;
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator<=(const Real<N, T>& x, const U y)
+constexpr bool operator<=(const Real<N, T>& x, const U y)
 {
     return x[0] <= y;
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator>=(const Real<N, T>& x, const U y)
+constexpr bool operator>=(const Real<N, T>& x, const U y)
 {
     return x[0] >= y;
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator==(const U x, const Real<N, T>& y)
+constexpr bool operator==(const U x, const Real<N, T>& y)
 {
     return x == y[0];
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator!=(const U x, const Real<N, T>& y)
+constexpr bool operator!=(const U x, const Real<N, T>& y)
 {
     return x != y[0];
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator<(const U x, const Real<N, T>& y)
+constexpr bool operator<(const U x, const Real<N, T>& y)
 {
     return x < y[0];
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator>(const U x, const Real<N, T>& y)
+constexpr bool operator>(const U x, const Real<N, T>& y)
 {
     return x > y[0];
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator<=(const U x, const Real<N, T>& y)
+constexpr bool operator<=(const U x, const Real<N, T>& y)
 {
     return x <= y[0];
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator>=(const U x, const Real<N, T>& y)
+constexpr bool operator>=(const U x, const Real<N, T>& y)
 {
     return x >= y[0];
 }

--- a/autodiff/forward/real/real.hpp
+++ b/autodiff/forward/real/real.hpp
@@ -401,7 +401,7 @@ auto exp(const Real<N, T>& x)
 template<size_t N, typename T>
 auto log(const Real<N, T>& x)
 {
-    assert(x[0] != 0 && "autodiff::log(x) has undefined value and derivatives when x = 0");
+    assert((x[0] != 0) && "autodiff::log(x) has undefined value and derivatives when x = 0");
     Real<N, T> res = log(x[0]); // std::log is not constexpr
     For<1, N + 1>([&](auto i) constexpr {
         res[i] = x[i] - Sum<1, i>([&](auto j) constexpr {
@@ -416,7 +416,7 @@ auto log(const Real<N, T>& x)
 template<size_t N, typename T>
 auto log10(const Real<N, T>& x)
 {
-    assert(x[0] != 0 && "autodiff::log10(x) has undefined value and derivatives when x = 0");
+    assert((x[0] != 0) && "autodiff::log10(x) has undefined value and derivatives when x = 0");
     constexpr auto ln10 = 2.302585092994046;
     return log(x) / ln10;
 }
@@ -427,7 +427,7 @@ auto sqrt(const Real<N, T>& x)
     Real<N, T> res = sqrt(x[0]); // std::sqrt is not constexpr
 
     if constexpr(N > 0) {
-        // assert(x[0] != 0 && "autodiff::sqrt(x) has undefined derivatives when x = 0");
+        // (assert((x[0] != 0) && "autodiff::sqrt(x) has undefined derivatives when x = 0");
         if(x[0] == 0)
             return res;
         Real<N, T> a;
@@ -453,7 +453,7 @@ auto cbrt(const Real<N, T>& x)
     Real<N, T> res = cbrt(x[0]); // std::cbrt is not constexpr
 
     if constexpr(N > 0) {
-        // assert(x[0] != 0 && "autodiff::cbrt(x) has undefined derivatives when x = 0");
+        // assert((x[0] != 0) && "autodiff::cbrt(x) has undefined derivatives when x = 0");
         if(x[0] == 0)
             return res;
         Real<N, T> a;
@@ -479,7 +479,7 @@ auto pow(const Real<N, T>& x, const Real<N, T>& y)
     Real<N, T> res = pow(x[0], y[0]); // std::pow is not constexpr
 
     if constexpr(N > 0) {
-        // assert(x[0] != 0 && "autodiff::pow(x, y) has undefined derivatives when x = 0");
+        // assert((x[0] != 0) && "autodiff::pow(x, y) has undefined derivatives when x = 0");
         if(x[0] == 0)
             return res;
         const auto lnx = log(x);
@@ -505,7 +505,7 @@ auto pow(const Real<N, T>& x, const U u)
     Real<N, T> res = pow(x[0], static_cast<T>(u)); // std::pow is not constexpr
 
     if constexpr(N > 0) {
-        // assert(x[0] != 0 && "autodiff::pow(x, y) has undefined derivatives when x = 0");
+        // assert((x[0] != 0) && "autodiff::pow(x, y) has undefined derivatives when x = 0");
         if(x[0] == 0)
             return res;
         const auto a = u * log(x);
@@ -525,7 +525,7 @@ auto pow(const U u, const Real<N, T>& y)
     Real<N, T> res = pow(static_cast<T>(u), y[0]); // std::pow is not constexpr
 
     if constexpr(N > 0) {
-        // assert(u != 0 && "autodiff::pow(x, y) has undefined derivatives when x = 0");
+        // assert((u != 0) && "autodiff::pow(x, y) has undefined derivatives when x = 0");
         if(u == 0)
             return res;
         const auto a = y * log(u);
@@ -608,7 +608,7 @@ auto asin(const Real<N, T>& x)
     Real<N, T> res = asin(x[0]); // std::asin is not constexpr
 
     if constexpr(N > 0) {
-        assert(abs(x[0]) < 1.0 && "autodiff::asin(x) has undefined derivative when |x| >= 1");
+        assert((abs(x[0]) < 1) && "autodiff::asin(x) has undefined derivative when |x| >= 1");
         Real<N - 1, T> xprime;
         For<1, N + 1>([&](auto i) constexpr {
             xprime[i - 1] = x[i];
@@ -628,7 +628,7 @@ auto acos(const Real<N, T>& x)
     Real<N, T> res = acos(x[0]); // std::acos is not constexpr
 
     if constexpr(N > 0) {
-        assert(abs(x[0] < 1.0) && "autodiff::acos(x) has undefined derivative when |x| >= 1");
+        assert((abs(x[0]) < 1) && "autodiff::acos(x) has undefined derivative when |x| >= 1");
         Real<N - 1, T> xprime;
         For<1, N + 1>([&](auto i) constexpr {
             xprime[i - 1] = x[i];
@@ -805,7 +805,7 @@ constexpr auto acosh(const Real<N, T>& x)
     Real<N, T> res;
     res[0] = acosh(x[0]);
     if constexpr(N > 0) {
-        assert(x[0] > 1.0 && "autodiff::acosh(x) has undefined derivative when |x| <= 1");
+        assert((abs(x[0]) > 1) && "autodiff::acosh(x) has undefined derivative when |x| <= 1");
         Real<N - 1, T> aux(x);
         aux = 1 / sqrt(aux * aux - 1);
         For<1, N + 1>([&](auto i) constexpr {
@@ -821,7 +821,7 @@ constexpr auto atanh(const Real<N, T>& x)
     Real<N, T> res;
     res[0] = atanh(x[0]);
     if constexpr(N > 0) {
-        assert(x[0] < 1.0 && "autodiff::atanh(x) has undefined derivative when |x| >= 1");
+        assert((abs(x[0]) < 1) && "autodiff::atanh(x) has undefined derivative when |x| >= 1");
         Real<N - 1, T> aux(x);
         aux = 1 / (1 - aux * aux);
         For<1, N + 1>([&](auto i) constexpr {
@@ -843,7 +843,7 @@ constexpr auto abs(const Real<N, T>& x)
     Real<N, T> res;
     res[0] = std::abs(x[0]);
     if constexpr(N > 0) {
-        // assert(x[0] != 0 && "autodiff::abs(x) has undefined derivatives when x = 0");
+        // assert((x[0] != 0) && "autodiff::abs(x) has undefined derivatives when x = 0");
         if(x[0] == 0)
             return res;
         const T s = std::copysign(1.0, x[0]);

--- a/autodiff/forward/real/real.hpp
+++ b/autodiff/forward/real/real.hpp
@@ -338,13 +338,13 @@ constexpr auto operator*(Real<N, T> x, const Real<N, T>& y)
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-constexpr auto operator*(Real<N, T> x, const U& y)
+constexpr auto operator*(Real<N, T> x, const U y)
 {
     return x *= y;
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-constexpr auto operator*(const U& x, Real<N, T> y)
+constexpr auto operator*(const U x, Real<N, T> y)
 {
     return y *= x;
 }
@@ -362,16 +362,15 @@ constexpr auto operator/(Real<N, T> x, const Real<N, T>& y)
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-constexpr auto operator/(Real<N, T> x, const U& y)
+constexpr auto operator/(Real<N, T> x, const U y)
 {
     return x /= y;
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-constexpr auto operator/(const U& x, Real<N, T> y)
+constexpr auto operator/(const U x, const Real<N, T>& y)
 {
-    Real<N, T> z = x;
-    return z /= y;
+    return Real<N, T>(x) / y;
 }
 
 //=====================================================================================================================

--- a/autodiff/forward/real/real.hpp
+++ b/autodiff/forward/real/real.hpp
@@ -267,13 +267,13 @@ constexpr bool areReal = (... && isReal<Args>);
 //=====================================================================================================================
 
 template<size_t N, typename T>
-auto operator+(const Real<N, T>& x)
+constexpr auto operator+(const Real<N, T>& x)
 {
     return x;
 }
 
 template<size_t N, typename T>
-auto operator-(const Real<N, T>& x)
+constexpr auto operator-(const Real<N, T>& x)
 {
     Real<N, T> res;
     For<0, N + 1>([&](auto i) constexpr { res[i] = -x[i]; });
@@ -287,19 +287,19 @@ auto operator-(const Real<N, T>& x)
 //=====================================================================================================================
 
 template<size_t N, typename T>
-auto operator+(Real<N, T> x, const Real<N, T>& y)
+constexpr auto operator+(Real<N, T> x, const Real<N, T>& y)
 {
     return x += y;
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-auto operator+(Real<N, T> x, const U& y)
+constexpr auto operator+(Real<N, T> x, const U& y)
 {
     return x += y;
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-auto operator+(const U& x, Real<N, T> y)
+constexpr auto operator+(const U& x, Real<N, T> y)
 {
     return y += x;
 }
@@ -310,19 +310,19 @@ auto operator+(const U& x, Real<N, T> y)
 //
 //=====================================================================================================================
 template<size_t N, typename T>
-auto operator-(Real<N, T> x, const Real<N, T>& y)
+constexpr auto operator-(Real<N, T> x, const Real<N, T>& y)
 {
     return x -= y;
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-auto operator-(Real<N, T> x, const U& y)
+constexpr auto operator-(Real<N, T> x, const U& y)
 {
     return x -= y;
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-auto operator-(const U& x, Real<N, T> y)
+constexpr auto operator-(const U& x, Real<N, T> y)
 {
     y -= x;
     y *= -static_cast<T>(1.0);
@@ -336,19 +336,19 @@ auto operator-(const U& x, Real<N, T> y)
 //=====================================================================================================================
 
 template<size_t N, typename T>
-auto operator*(Real<N, T> x, const Real<N, T>& y)
+constexpr auto operator*(Real<N, T> x, const Real<N, T>& y)
 {
     return x *= y;
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-auto operator*(Real<N, T> x, const U& y)
+constexpr auto operator*(Real<N, T> x, const U& y)
 {
     return x *= y;
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-auto operator*(const U& x, Real<N, T> y)
+constexpr auto operator*(const U& x, Real<N, T> y)
 {
     return y *= x;
 }
@@ -360,19 +360,19 @@ auto operator*(const U& x, Real<N, T> y)
 //=====================================================================================================================
 
 template<size_t N, typename T>
-auto operator/(Real<N, T> x, const Real<N, T>& y)
+constexpr auto operator/(Real<N, T> x, const Real<N, T>& y)
 {
     return x /= y;
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-auto operator/(Real<N, T> x, const U& y)
+constexpr auto operator/(Real<N, T> x, const U& y)
 {
     return x /= y;
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-auto operator/(const U& x, Real<N, T> y)
+constexpr auto operator/(const U& x, Real<N, T> y)
 {
     Real<N, T> z = x;
     return z /= y;

--- a/autodiff/forward/real/real.hpp
+++ b/autodiff/forward/real/real.hpp
@@ -273,11 +273,9 @@ constexpr auto operator+(const Real<N, T>& x)
 }
 
 template<size_t N, typename T>
-constexpr auto operator-(const Real<N, T>& x)
+constexpr auto operator-(Real<N, T> x)
 {
-    Real<N, T> res;
-    For<0, N + 1>([&](auto i) constexpr { res[i] = -x[i]; });
-    return res;
+    return x *= -1;
 }
 
 //=====================================================================================================================

--- a/autodiff/forward/real/real.hpp
+++ b/autodiff/forward/real/real.hpp
@@ -297,13 +297,13 @@ constexpr auto operator+(Real<N, T> x, const Real<N, T>& y)
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-constexpr auto operator+(Real<N, T> x, const U& y)
+constexpr auto operator+(Real<N, T> x, const U y)
 {
     return x += y;
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-constexpr auto operator+(const U& x, Real<N, T> y)
+constexpr auto operator+(const U x, Real<N, T> y)
 {
     return y += x;
 }
@@ -947,63 +947,63 @@ bool operator>=(const Real<N, T>& x, const Real<N, T>& y)
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator==(const Real<N, T>& x, const U& y)
+bool operator==(const Real<N, T>& x, const U y)
 {
     return x[0] == y;
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator!=(const Real<N, T>& x, const U& y)
+bool operator!=(const Real<N, T>& x, const U y)
 {
     return x[0] != y;
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator<(const Real<N, T>& x, const U& y)
+bool operator<(const Real<N, T>& x, const U y)
 {
     return x[0] < y;
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator>(const Real<N, T>& x, const U& y)
+bool operator>(const Real<N, T>& x, const U y)
 {
     return x[0] > y;
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator<=(const Real<N, T>& x, const U& y)
+bool operator<=(const Real<N, T>& x, const U y)
 {
     return x[0] <= y;
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator>=(const Real<N, T>& x, const U& y)
+bool operator>=(const Real<N, T>& x, const U y)
 {
     return x[0] >= y;
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator==(const U& x, const Real<N, T>& y)
+bool operator==(const U x, const Real<N, T>& y)
 {
     return x == y[0];
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator!=(const U& x, const Real<N, T>& y)
+bool operator!=(const U x, const Real<N, T>& y)
 {
     return x != y[0];
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator<(const U& x, const Real<N, T>& y)
+bool operator<(const U x, const Real<N, T>& y)
 {
     return x < y[0];
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator>(const U& x, const Real<N, T>& y)
+bool operator>(const U x, const Real<N, T>& y)
 {
     return x > y[0];
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator<=(const U& x, const Real<N, T>& y)
+bool operator<=(const U x, const Real<N, T>& y)
 {
     return x <= y[0];
 }
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-bool operator>=(const U& x, const Real<N, T>& y)
+bool operator>=(const U x, const Real<N, T>& y)
 {
     return x >= y[0];
 }

--- a/autodiff/forward/real/real.hpp
+++ b/autodiff/forward/real/real.hpp
@@ -55,18 +55,23 @@ class Real
     static_assert(isArithmetic<T>);
 
     /// The value and derivatives of the number up to order *N*.
-    std::array<T, N + 1> m_data = {};
+    std::array<T, N + 1> m_data;
 
   public:
     /// Construct a default Real number of order *N* and type *T*.
     constexpr Real()
+        : m_data{}
     {
     }
 
     /// Construct a Real number with given data.
-    constexpr Real(const T& value)
+    constexpr Real(const T value)
+        : m_data{}
     {
         m_data[0] = value;
+        For<1, N + 1>([&](auto i) constexpr {
+            m_data[i] = T{0};
+        });
     }
 
     /// Construct a Real number with given data.
@@ -78,6 +83,7 @@ class Real
     /// Construct a Real number with given data.
     template<size_t M, typename U, Requires<isArithmetic<U>> = true>
     constexpr explicit Real(const Real<M, U>& other)
+        : m_data{}
     {
         static_assert(N <= M);
         For<0, N + 1>([&](auto i) constexpr {
@@ -108,10 +114,10 @@ class Real
     }
 
     template<typename U, Requires<isArithmetic<U>> = true>
-    constexpr auto operator=(const U& value) -> Real&
+    constexpr auto operator=(const U value) -> Real&
     {
-        m_data[0] = value;
-        For<1, N + 1>([&](auto i) constexpr { m_data[i] = T{}; });
+        m_data[0] = static_cast<T>(value);
+        For<1, N + 1>([&](auto i) constexpr { m_data[i] = T{0}; });
         return *this;
     }
 
@@ -122,28 +128,28 @@ class Real
     }
 
     template<typename U, Requires<isArithmetic<U>> = true>
-    constexpr auto operator+=(const U& value) -> Real&
+    constexpr auto operator+=(const U value) -> Real&
     {
         m_data[0] += static_cast<T>(value);
         return *this;
     }
 
     template<typename U, Requires<isArithmetic<U>> = true>
-    constexpr auto operator-=(const U& value) -> Real&
+    constexpr auto operator-=(const U value) -> Real&
     {
         m_data[0] -= static_cast<T>(value);
         return *this;
     }
 
     template<typename U, Requires<isArithmetic<U>> = true>
-    constexpr auto operator*=(const U& value) -> Real&
+    constexpr auto operator*=(const U value) -> Real&
     {
         For<0, N + 1>([&](auto i) constexpr { m_data[i] *= static_cast<T>(value); });
         return *this;
     }
 
     template<typename U, Requires<isArithmetic<U>> = true>
-    constexpr auto operator/=(const U& value) -> Real&
+    constexpr auto operator/=(const U value) -> Real&
     {
         For<0, N + 1>([&](auto i) constexpr { m_data[i] /= static_cast<T>(value); });
         return *this;

--- a/autodiff/forward/real/real.hpp
+++ b/autodiff/forward/real/real.hpp
@@ -828,14 +828,14 @@ constexpr auto atanh(const Real<N, T>& x)
 //=====================================================================================================================
 //
 // OTHER FUNCTIONS
-//
+//      abs, min, max
 //=====================================================================================================================
 
 template<size_t N, typename T>
-constexpr auto abs(const Real<N, T>& x)
+auto abs(const Real<N, T>& x)
 {
-    Real<N, T> res;
-    res[0] = std::abs(x[0]);
+    Real<N, T> res = abs(x[0]); // std::abs is not constexpr
+
     if constexpr(N > 0) {
         // assert((x[0] != 0) && "autodiff::abs(x) has undefined derivatives when x = 0");
         if(x[0] == 0)
@@ -855,13 +855,13 @@ constexpr auto min(const Real<N, T>& x, const Real<N, T>& y)
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-constexpr auto min(const Real<N, T>& x, const U& y)
+constexpr auto min(const Real<N, T>& x, const U y)
 {
     return (x[0] <= y) ? x : y;
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-constexpr auto min(const U& x, const Real<N, T>& y)
+constexpr auto min(const U x, const Real<N, T>& y)
 {
     return (x < y[0]) ? x : y;
 }
@@ -873,13 +873,13 @@ constexpr auto max(const Real<N, T>& x, const Real<N, T>& y)
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-constexpr auto max(const Real<N, T>& x, const U& y)
+constexpr auto max(const Real<N, T>& x, const U y)
 {
     return (x[0] >= y) ? x : y;
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-constexpr auto max(const U& x, const Real<N, T>& y)
+constexpr auto max(const U x, const Real<N, T>& y)
 {
     return (x > y[0]) ? x : y;
 }

--- a/autodiff/forward/real/real.hpp
+++ b/autodiff/forward/real/real.hpp
@@ -546,13 +546,10 @@ auto pow(const U u, const Real<N, T>& y)
 //=====================================================================================================================
 
 template<size_t N, typename T>
-auto sincos(const Real<N, T>& x) -> std::tuple<Real<N, T>, Real<N, T>>
+auto sincos(const Real<N, T>& x) -> std::array<Real<N, T>, 2>
 {
-    Real<N, T> sinx;
-    Real<N, T> cosx;
-
-    cosx[0] = cos(x[0]);
-    sinx[0] = sin(x[0]);
+    Real<N, T> sinx = sin(x[0]); // std::sin is not constexpr
+    Real<N, T> cosx = cos(x[0]); // std::cos is not constexpr
 
     For<1, N + 1>([&](auto i) constexpr {
         cosx[i] = -Sum<0, i>([&](auto j) constexpr {
@@ -572,24 +569,22 @@ auto sincos(const Real<N, T>& x) -> std::tuple<Real<N, T>, Real<N, T>>
 template<size_t N, typename T>
 auto sin(const Real<N, T>& x)
 {
-    return std::get<0>(sincos(x));
+    return sincos(x)[0];
 }
 
 template<size_t N, typename T>
 auto cos(const Real<N, T>& x)
 {
-    return std::get<1>(sincos(x));
+    return sincos(x)[1];
 }
 
 template<size_t N, typename T>
 auto tan(const Real<N, T>& x)
 {
-    Real<N, T> tanx;
-    tanx[0] = tan(x[0]);
+    Real<N, T> tanx = tan(x[0]); // std::tan is not constexpr
 
     if constexpr(N > 0) {
-        Real<N, T> aux;
-        aux[0] = 1 + tanx[0] * tanx[0];
+        Real<N, T> aux = 1 + tanx[0] * tanx[0];
 
         For<1, N + 1>([&](auto i) constexpr {
             tanx[i] = Sum<0, i>([&](auto j) constexpr {
@@ -608,12 +603,12 @@ auto tan(const Real<N, T>& x)
 }
 
 template<size_t N, typename T>
-constexpr auto asin(const Real<N, T>& x)
+auto asin(const Real<N, T>& x)
 {
-    Real<N, T> res;
-    res[0] = asin(x[0]);
+    Real<N, T> res = asin(x[0]); // std::asin is not constexpr
+
     if constexpr(N > 0) {
-        assert(x[0] < 1.0 && "autodiff::asin(x) has undefined derivative when |x| >= 1");
+        assert(abs(x[0]) < 1.0 && "autodiff::asin(x) has undefined derivative when |x| >= 1");
         Real<N - 1, T> xprime;
         For<1, N + 1>([&](auto i) constexpr {
             xprime[i - 1] = x[i];
@@ -628,12 +623,12 @@ constexpr auto asin(const Real<N, T>& x)
 }
 
 template<size_t N, typename T>
-constexpr auto acos(const Real<N, T>& x)
+auto acos(const Real<N, T>& x)
 {
-    Real<N, T> res;
-    res[0] = acos(x[0]);
+    Real<N, T> res = acos(x[0]); // std::acos is not constexpr
+
     if constexpr(N > 0) {
-        assert(x[0] < 1.0 && "autodiff::acos(x) has undefined derivative when |x| >= 1");
+        assert(abs(x[0] < 1.0) && "autodiff::acos(x) has undefined derivative when |x| >= 1");
         Real<N - 1, T> xprime;
         For<1, N + 1>([&](auto i) constexpr {
             xprime[i - 1] = x[i];
@@ -648,10 +643,10 @@ constexpr auto acos(const Real<N, T>& x)
 }
 
 template<size_t N, typename T>
-constexpr auto atan(const Real<N, T>& x)
+auto atan(const Real<N, T>& x)
 {
-    Real<N, T> res;
-    res[0] = atan(x[0]);
+    Real<N, T> res = atan(x[0]); // std::atan is not constexpr
+
     if constexpr(N > 0) {
         Real<N - 1, T> xprime;
         For<1, N + 1>([&](auto i) constexpr {
@@ -667,11 +662,11 @@ constexpr auto atan(const Real<N, T>& x)
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-constexpr auto atan2(const U& c, const Real<N, T>& x)
+auto atan2(const U c, const Real<N, T>& x)
 {
     // d[atan2(c,x)]/dx = -c / (c^2 + x^2)
-    Real<N, T> res;
-    res[0] = atan2(c, x[0]);
+    Real<N, T> res = atan2(c, x[0]); // std::atan2 is not constexpr
+
     if constexpr(N > 0) {
         Real<N - 1, T> xprime;
         For<1, N + 1>([&](auto i) constexpr {
@@ -687,11 +682,11 @@ constexpr auto atan2(const U& c, const Real<N, T>& x)
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-constexpr auto atan2(const Real<N, T>& y, const U& c)
+auto atan2(const Real<N, T>& y, const U c)
 {
     // d[atan2(y,c)]/dy = c / (c^2 + y^2)
-    Real<N, T> res;
-    res[0] = atan2(y[0], c);
+    Real<N, T> res = atan2(y[0], c); // std::atan2 is not constexpr
+
     if constexpr(N > 0) {
         Real<N - 1, T> yprime;
         For<1, N + 1>([&](auto i) constexpr {
@@ -707,12 +702,12 @@ constexpr auto atan2(const Real<N, T>& y, const U& c)
 }
 
 template<size_t N, typename T>
-constexpr auto atan2(const Real<N, T>& y, const Real<N, T>& x)
+auto atan2(const Real<N, T>& y, const Real<N, T>& x)
 {
-    Real<N, T> res;
-    res[0] = atan2(y[0], x[0]);
+    Real<N, T> res = atan2(y[0], x[0]); // std::atan2 is not constexpr
+
     if constexpr(N > 0) {
-        const T denom = x[0] * x[0] + y[0] * y[0];
+        const auto denom = x[0] * x[0] + y[0] * y[0];
         For<1, N + 1>([&](auto i) constexpr {
             res[i] = (x[0] * y[i] - x[i] * y[0]) / denom;
         });

--- a/autodiff/forward/real/real.hpp
+++ b/autodiff/forward/real/real.hpp
@@ -314,17 +314,15 @@ constexpr auto operator-(Real<N, T> x, const Real<N, T>& y)
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-constexpr auto operator-(Real<N, T> x, const U& y)
+constexpr auto operator-(Real<N, T> x, const U y)
 {
     return x -= y;
 }
 
 template<size_t N, typename T, typename U, Requires<isArithmetic<U>> = true>
-constexpr auto operator-(const U& x, Real<N, T> y)
+constexpr auto operator-(const U x, Real<N, T> y)
 {
-    y -= x;
-    y *= -static_cast<T>(1.0);
-    return y;
+    return -(y - x);
 }
 
 //=====================================================================================================================

--- a/autodiff/forward/real/real.hpp
+++ b/autodiff/forward/real/real.hpp
@@ -202,6 +202,9 @@ class Real
         return static_cast<U>(m_data[0]);
     }
 #endif
+
+    template<size_t M, typename U>
+    friend bool operator==(const Real<M, U>& x, const Real<M, U>& y);
 };
 
 //=====================================================================================================================
@@ -929,11 +932,7 @@ auto repr(const Real<N, T>& x)
 template<size_t N, typename T>
 bool operator==(const Real<N, T>& x, const Real<N, T>& y)
 {
-    bool res = true;
-    For<0, N + 1>([&](auto i) constexpr {
-        res = res && x[i] == y[i];
-    });
-    return res;
+    return std::equal(x.m_data.begin(), x.m_data.end(), y.m_data.begin(), y.m_data.end());
 }
 
 template<size_t N, typename T>

--- a/tests/forward/real/eigen.test.cpp
+++ b/tests/forward/real/eigen.test.cpp
@@ -33,7 +33,6 @@
 #include <tests/utils/catch.hpp>
 using namespace autodiff;
 
-
 TEST_CASE("testing autodiff::real (with eigen)", "[forward][real][eigen]")
 {
     using Eigen::MatrixXd;
@@ -41,34 +40,34 @@ TEST_CASE("testing autodiff::real (with eigen)", "[forward][real][eigen]")
 
     SECTION("testing array-unpacking of derivatives for eigen vector of real numbers")
     {
-        real4th x = {{ 2.0, 3.0, 4.0, 5.0, 6.0 }};
-        real4th y = {{ 3.0, 4.0, 5.0, 6.0, 7.0 }};
-        real4th z = {{ 4.0, 5.0, 6.0, 7.0, 8.0 }};
+        real4th x = {{2.0, 3.0, 4.0, 5.0, 6.0}};
+        real4th y = {{3.0, 4.0, 5.0, 6.0, 7.0}};
+        real4th z = {{4.0, 5.0, 6.0, 7.0, 8.0}};
 
         VectorXreal4th u(3);
         u << x, y, z;
 
         auto [u0, u1, u2, u3, u4] = derivatives(u);
 
-        CHECK( u0[0] == approx(derivative<0>(x)) );
-        CHECK( u0[1] == approx(derivative<0>(y)) );
-        CHECK( u0[2] == approx(derivative<0>(z)) );
+        CHECK(u0[0] == approx(derivative<0>(x)));
+        CHECK(u0[1] == approx(derivative<0>(y)));
+        CHECK(u0[2] == approx(derivative<0>(z)));
 
-        CHECK( u1[0] == approx(derivative<1>(x)) );
-        CHECK( u1[1] == approx(derivative<1>(y)) );
-        CHECK( u1[2] == approx(derivative<1>(z)) );
+        CHECK(u1[0] == approx(derivative<1>(x)));
+        CHECK(u1[1] == approx(derivative<1>(y)));
+        CHECK(u1[2] == approx(derivative<1>(z)));
 
-        CHECK( u2[0] == approx(derivative<2>(x)) );
-        CHECK( u2[1] == approx(derivative<2>(y)) );
-        CHECK( u2[2] == approx(derivative<2>(z)) );
+        CHECK(u2[0] == approx(derivative<2>(x)));
+        CHECK(u2[1] == approx(derivative<2>(y)));
+        CHECK(u2[2] == approx(derivative<2>(z)));
 
-        CHECK( u3[0] == approx(derivative<3>(x)) );
-        CHECK( u3[1] == approx(derivative<3>(y)) );
-        CHECK( u3[2] == approx(derivative<3>(z)) );
+        CHECK(u3[0] == approx(derivative<3>(x)));
+        CHECK(u3[1] == approx(derivative<3>(y)));
+        CHECK(u3[2] == approx(derivative<3>(z)));
 
-        CHECK( u4[0] == approx(derivative<4>(x)) );
-        CHECK( u4[1] == approx(derivative<4>(y)) );
-        CHECK( u4[2] == approx(derivative<4>(z)) );
+        CHECK(u4[0] == approx(derivative<4>(x)));
+        CHECK(u4[1] == approx(derivative<4>(y)));
+        CHECK(u4[2] == approx(derivative<4>(z)));
 
         auto u0th = derivative<0>(u);
         auto u1th = derivative<1>(u);
@@ -76,51 +75,51 @@ TEST_CASE("testing autodiff::real (with eigen)", "[forward][real][eigen]")
         auto u3th = derivative<3>(u);
         auto u4th = derivative<4>(u);
 
-        CHECK( u0th.size() == 3);
-        CHECK( u1th.size() == 3);
-        CHECK( u2th.size() == 3);
-        CHECK( u3th.size() == 3);
-        CHECK( u4th.size() == 3);
+        CHECK(u0th.size() == 3);
+        CHECK(u1th.size() == 3);
+        CHECK(u2th.size() == 3);
+        CHECK(u3th.size() == 3);
+        CHECK(u4th.size() == 3);
 
-        CHECK( u0th[0] == derivative<0>(x) );
-        CHECK( u0th[1] == derivative<0>(y) );
-        CHECK( u0th[2] == derivative<0>(z) );
+        CHECK(u0th[0] == derivative<0>(x));
+        CHECK(u0th[1] == derivative<0>(y));
+        CHECK(u0th[2] == derivative<0>(z));
 
-        CHECK( u1th[0] == derivative<1>(x) );
-        CHECK( u1th[1] == derivative<1>(y) );
-        CHECK( u1th[2] == derivative<1>(z) );
+        CHECK(u1th[0] == derivative<1>(x));
+        CHECK(u1th[1] == derivative<1>(y));
+        CHECK(u1th[2] == derivative<1>(z));
 
-        CHECK( u2th[0] == derivative<2>(x) );
-        CHECK( u2th[1] == derivative<2>(y) );
-        CHECK( u2th[2] == derivative<2>(z) );
+        CHECK(u2th[0] == derivative<2>(x));
+        CHECK(u2th[1] == derivative<2>(y));
+        CHECK(u2th[2] == derivative<2>(z));
 
-        CHECK( u3th[0] == derivative<3>(x) );
-        CHECK( u3th[1] == derivative<3>(y) );
-        CHECK( u3th[2] == derivative<3>(z) );
+        CHECK(u3th[0] == derivative<3>(x));
+        CHECK(u3th[1] == derivative<3>(y));
+        CHECK(u3th[2] == derivative<3>(z));
 
-        CHECK( u4th[0] == derivative<4>(x) );
-        CHECK( u4th[1] == derivative<4>(y) );
-        CHECK( u4th[2] == derivative<4>(z) );
+        CHECK(u4th[0] == derivative<4>(x));
+        CHECK(u4th[1] == derivative<4>(y));
+        CHECK(u4th[2] == derivative<4>(z));
 
-        CHECK( u0th[0] == grad<0>(x) );
-        CHECK( u0th[1] == grad<0>(y) );
-        CHECK( u0th[2] == grad<0>(z) );
+        CHECK(u0th[0] == grad<0>(x));
+        CHECK(u0th[1] == grad<0>(y));
+        CHECK(u0th[2] == grad<0>(z));
 
-        CHECK( u1th[0] == grad<1>(x) );
-        CHECK( u1th[1] == grad<1>(y) );
-        CHECK( u1th[2] == grad<1>(z) );
+        CHECK(u1th[0] == grad<1>(x));
+        CHECK(u1th[1] == grad<1>(y));
+        CHECK(u1th[2] == grad<1>(z));
 
-        CHECK( u2th[0] == grad<2>(x) );
-        CHECK( u2th[1] == grad<2>(y) );
-        CHECK( u2th[2] == grad<2>(z) );
+        CHECK(u2th[0] == grad<2>(x));
+        CHECK(u2th[1] == grad<2>(y));
+        CHECK(u2th[2] == grad<2>(z));
 
-        CHECK( u3th[0] == grad<3>(x) );
-        CHECK( u3th[1] == grad<3>(y) );
-        CHECK( u3th[2] == grad<3>(z) );
+        CHECK(u3th[0] == grad<3>(x));
+        CHECK(u3th[1] == grad<3>(y));
+        CHECK(u3th[2] == grad<3>(z));
 
-        CHECK( u4th[0] == grad<4>(x) );
-        CHECK( u4th[1] == grad<4>(y) );
-        CHECK( u4th[2] == grad<4>(z) );
+        CHECK(u4th[0] == grad<4>(x));
+        CHECK(u4th[1] == grad<4>(y));
+        CHECK(u4th[2] == grad<4>(z));
     }
 
     SECTION("testing casting to VectorXd")
@@ -131,7 +130,7 @@ TEST_CASE("testing autodiff::real (with eigen)", "[forward][real][eigen]")
         VectorXd y = x.cast<double>();
 
         for(auto i = 0; i < 3; ++i)
-            CHECK( x[i] == approx(y(i)) );
+            CHECK(x[i] == approx(y(i)));
     }
 
     SECTION("testing casting to MatriXd")
@@ -152,25 +151,24 @@ TEST_CASE("testing autodiff::real (with eigen)", "[forward][real][eigen]")
         A << 1.0, 3.0, 5.0, 7.0;
 
         VectorXreal x(2);
-        x[0] = { 1.0, 3.0 };
-        x[1] = { 2.0, 5.0 };
+        x[0] = {1.0, 3.0};
+        x[1] = {2.0, 5.0};
 
         VectorXreal b = A * x;
 
-        CHECK( derivative<0>(b[0]) == approx(7.0) );
-        CHECK( derivative<0>(b[1]) == approx(19.0) );
+        CHECK(derivative<0>(b[0]) == approx(7.0));
+        CHECK(derivative<0>(b[1]) == approx(19.0));
 
-        CHECK( derivative<1>(b[0]) == approx(18.0) );
-        CHECK( derivative<1>(b[1]) == approx(50.0) );
+        CHECK(derivative<1>(b[0]) == approx(18.0));
+        CHECK(derivative<1>(b[1]) == approx(50.0));
     }
 
     SECTION("testing gradient derivatives")
     {
         SECTION("using VectorXreal")
         {
-            auto f = [](const VectorXreal& x) -> real
-            {
-                return 0.5 * ( x.array() * x.array() ).sum();
+            auto f = [](const VectorXreal& x) -> real {
+                return 0.5 * (x.array() * x.array()).sum();
             };
 
             VectorXreal x(3);
@@ -178,16 +176,15 @@ TEST_CASE("testing autodiff::real (with eigen)", "[forward][real][eigen]")
 
             VectorXd g = gradient(f, wrt(x), at(x));
 
-            CHECK( g[0] == approx(x[0]) );
-            CHECK( g[1] == approx(x[1]) );
-            CHECK( g[2] == approx(x[2]) );
+            CHECK(g[0] == approx(x[0]));
+            CHECK(g[1] == approx(x[1]));
+            CHECK(g[2] == approx(x[2]));
         }
 
         SECTION("using Eigen::Map<VectorXreal>")
         {
-            auto f = [](const VectorXreal& x) -> real
-            {
-                return 0.5 * ( x.array() * x.array() ).sum();
+            auto f = [](const VectorXreal& x) -> real {
+                return 0.5 * (x.array() * x.array()).sum();
             };
 
             VectorXreal vec(3);
@@ -197,9 +194,9 @@ TEST_CASE("testing autodiff::real (with eigen)", "[forward][real][eigen]")
 
             VectorXd g = gradient(f, wrt(x), at(x));
 
-            CHECK( g[0] == approx(x[0]) );
-            CHECK( g[1] == approx(x[1]) );
-            CHECK( g[2] == approx(x[2]) );
+            CHECK(g[0] == approx(x[0]));
+            CHECK(g[1] == approx(x[1]));
+            CHECK(g[2] == approx(x[2]));
         }
     }
 
@@ -207,8 +204,7 @@ TEST_CASE("testing autodiff::real (with eigen)", "[forward][real][eigen]")
     {
         SECTION("using VectorXreal")
         {
-            auto f = [](const VectorXreal& x) -> VectorXreal
-            {
+            auto f = [](const VectorXreal& x) -> VectorXreal {
                 return x / x.array().sum();
             };
 
@@ -223,13 +219,12 @@ TEST_CASE("testing autodiff::real (with eigen)", "[forward][real][eigen]")
 
             for(auto i = 0; i < 3; ++i)
                 for(auto j = 0; j < 3; ++j)
-                    CHECK( J(i, j) == approx(-F[i] + ((i == j) ? 1.0 : 0.0)) );
+                    CHECK(J(i, j) == approx(-F[i] + ((i == j) ? 1.0 : 0.0)));
         }
 
         SECTION("using Eigen::Map<VectorXreal>")
         {
-            auto f = [](const VectorXreal& x) -> VectorXreal
-            {
+            auto f = [](const VectorXreal& x) -> VectorXreal {
                 return x / x.array().sum();
             };
 
@@ -242,7 +237,7 @@ TEST_CASE("testing autodiff::real (with eigen)", "[forward][real][eigen]")
 
             for(auto i = 0; i < 3; ++i)
                 for(auto j = 0; j < 3; ++j)
-                    CHECK( J(i, j) == approx(-F[i] + ((i == j) ? 1.0 : 0.0)) );
+                    CHECK(J(i, j) == approx(-F[i] + ((i == j) ? 1.0 : 0.0)));
         }
     }
 }

--- a/tests/forward/real/real.test.cpp
+++ b/tests/forward/real/real.test.cpp
@@ -464,6 +464,99 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
     //=====================================================================================================================
     //
     // TESTING OTHER FUNCTIONS
+    //      abs, min, max
+    //=====================================================================================================================
+
+    SECTION("abs function")
+    {
+        constexpr auto x = real4th({0.5, 3.0, -5.0, -15.0, 11.0});
+        CHECK(abs(x) == x);
+        CHECK(abs(-x) == x);
+    }
+
+    SECTION("min function")
+    {
+        constexpr auto x = real4th({0.5, 3.0, -5.0, -15.0, 11.0});
+
+        // (real, real)
+        {
+            constexpr auto y = real4th({4.5, 3.0, -5.0, -15.0, 11.0});
+            constexpr auto a = min(x, y);
+            constexpr auto b = min(y, x);
+            CHECK(a == x);
+            CHECK(b == x);
+        }
+
+        // (real, smaller scalar)
+        {
+            constexpr auto y = real4th(0.2);
+            constexpr auto a = min(x, y);
+            constexpr auto b = min(y, x);
+            CHECK(a == y);
+            CHECK(b == y);
+        }
+
+        // (real, same scalar)
+        {
+            constexpr auto x0 = real4th(x[0]);
+            constexpr auto a = min(x, x0);
+            constexpr auto b = min(x0, x);
+            CHECK(a == x);
+            CHECK(b == x0);
+        }
+
+        // (real, larger scalar)
+        {
+            constexpr auto a = min(x, 3.5);
+            constexpr auto b = min(3.5, x);
+            CHECK(a == x);
+            CHECK(b == x);
+        }
+    }
+
+    SECTION("max function")
+    {
+        constexpr auto x = real4th({0.5, 3.0, -5.0, -15.0, 11.0});
+
+        // (real, real)
+        {
+            constexpr auto y = real4th({4.5, 3.0, -5.0, -15.0, 11.0});
+            constexpr auto a = max(x, y);
+            constexpr auto b = max(y, x);
+            CHECK(a == y);
+            CHECK(b == y);
+        }
+
+        // (real, smaller scalar)
+        {
+            constexpr auto a = max(x, 0.2);
+            constexpr auto b = max(0.2, x);
+            CHECK(a == x);
+            CHECK(b == x);
+        }
+
+        // (real, same scalar)
+        {
+            constexpr auto x0 = real4th(x[0]);
+            constexpr auto a = max(x, x0);
+            constexpr auto b = max(x0, x);
+            CHECK(a == x);
+            CHECK(b == x0);
+        }
+
+        // (real, larger scalar)
+        {
+            constexpr auto y = real4th(3.5);
+            constexpr auto a = max(x, y);
+            constexpr auto b = max(y, x);
+            CHECK(a == y);
+            CHECK(b == y);
+        }
+    }
+
+    //=====================================================================================================================
+    //
+    // TESTING COMPARISON OPERATORS
     //
     //=====================================================================================================================
 
@@ -476,71 +569,6 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
     x = {0.5, 3.0, -5.0, -15.0, 11.0};
     y = -x;
     z = y / 5.0;
-
-    y = abs(x);
-
-    CHECK_APPROX(y[0], std::abs(x[0]));
-    CHECK_APPROX(y[1], std::abs(x[0]) / x[0] * x[1]);
-    CHECK_APPROX(y[2], std::abs(x[0]) / x[0] * x[2]);
-    CHECK_APPROX(y[3], std::abs(x[0]) / x[0] * x[3]);
-    CHECK_APPROX(y[4], std::abs(x[0]) / x[0] * x[4]);
-
-    y = -x;
-    z = abs(y);
-
-    CHECK_APPROX(z[0], std::abs(y[0]));
-    CHECK_APPROX(z[1], std::abs(y[0]) / (y[0]) * y[1]);
-    CHECK_APPROX(z[2], std::abs(y[0]) / (y[0]) * y[2]);
-    CHECK_APPROX(z[3], std::abs(y[0]) / (y[0]) * y[3]);
-    CHECK_APPROX(z[4], std::abs(y[0]) / (y[0]) * y[4]);
-
-    //=====================================================================================================================
-    //
-    // TESTING MIN/MAX FUNCTIONS
-    //
-    //=====================================================================================================================
-
-    x = {0.5, 3.0, -5.0, -15.0, 11.0};
-    y = {4.5, 3.0, -5.0, -15.0, 11.0};
-
-    z = min(x, y);
-    CHECK(z == x);
-    z = min(y, x);
-    CHECK(z == x);
-    z = min(x, 0.1);
-    CHECK(z == real4th(0.1));
-    z = min(0.2, x);
-    CHECK(z == real4th(0.2));
-    z = min(0.5, x);
-    CHECK(z == x);
-    z = min(x, 0.5);
-    CHECK(z == x);
-    z = min(3.5, x);
-    CHECK(z == x);
-    z = min(x, 3.5);
-    CHECK(z == x);
-    z = max(x, y);
-    CHECK(z == y);
-    z = max(y, x);
-    CHECK(z == y);
-    z = max(x, 0.1);
-    CHECK(z == x);
-    z = max(0.2, x);
-    CHECK(z == x);
-    z = max(0.5, x);
-    CHECK(z == x);
-    z = max(x, 0.5);
-    CHECK(z == x);
-    z = max(8.5, x);
-    CHECK(z == real4th(8.5));
-    z = max(x, 8.5);
-    CHECK(z == real4th(8.5));
-
-    //=====================================================================================================================
-    //
-    // TESTING COMPARISON OPERATORS
-    //
-    //=====================================================================================================================
 
     x = {0.5, 3.0, -5.0, -15.0, 11.0};
 

--- a/tests/forward/real/real.test.cpp
+++ b/tests/forward/real/real.test.cpp
@@ -39,13 +39,6 @@
 
 using namespace autodiff;
 
-#define CHECK_4TH_ORDER_REAL_NUMBERS(a, b) \
-    CHECK_APPROX(a[0], b[0]);              \
-    CHECK_APPROX(a[1], b[1]);              \
-    CHECK_APPROX(a[2], b[2]);              \
-    CHECK_APPROX(a[3], b[3]);              \
-    CHECK_APPROX(a[4], b[4]);
-
 constexpr bool equalWithinAbs(const real4th a, const real4th b, const double tol = 1e-15)
 {
     for(int i = 0; i < 5; ++i)
@@ -60,6 +53,8 @@ constexpr auto pi = 3.14159265359;
 
 TEST_CASE("testing autodiff::real", "[forward][real]")
 {
+    // test ctor + equality comparison first -> then we can trust checks by equality comparisons of temporaries
+
     SECTION("Constructors")
     {
         constexpr auto tmp = real4th();
@@ -96,8 +91,6 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
             CHECK_FALSE(x == y);
         }
     }
-
-    // explicitly tested ctor + equality comparison -> now we can trust checks by equality comparisons of temporaries
 
     SECTION("Assignments")
     {
@@ -159,8 +152,6 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
 
     SECTION("Multiplication")
     {
-        using Catch::Matchers::WithinAbs;
-
         constexpr auto x = real4th({1, -3, 5, -7, 11});
         constexpr auto y = real4th({0.5, 3.0, -5.0, -15.0, 11.0});
 
@@ -181,8 +172,6 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
 
     SECTION("Division")
     {
-        using Catch::Matchers::WithinAbs;
-
         constexpr auto x = real4th({1, -3, 5, -7, 11});
         constexpr auto y = real4th({0.5, 3.0, -5.0, -15.0, 11.0});
 

--- a/tests/forward/real/real.test.cpp
+++ b/tests/forward/real/real.test.cpp
@@ -295,36 +295,44 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
     //
     //=====================================================================================================================
 
-    real4th x, y, z, u, v, w;
+    SECTION("sin/cos functions")
+    {
+        CHECK(sin(real4th(1.234)) == real4th(std::sin(1.234)));
+        CHECK(cos(real4th(1.234)) == real4th(std::cos(1.234)));
 
-    x = {0.5, 3.0, -5.0, -15.0, 11.0};
-    y = -x;
-    z = y / 5.0;
+        constexpr auto x = real4th({0.5, 3.0, -5.0, -15.0, 11.0});
+        const auto y0 = sin(x[0]);
+        const auto z0 = cos(x[0]);
+        const auto y1 = x[1] * z0;
+        const auto z1 = -x[1] * y0;
+        const auto y2 = x[2] * z0 + x[1] * z1;
+        const auto z2 = -x[2] * y0 - x[1] * y1;
+        const auto y3 = x[3] * z0 + 2 * x[2] * z1 + x[1] * z2;
+        const auto z3 = -x[3] * y0 - 2 * x[2] * y1 - x[1] * y2;
+        const auto y4 = x[4] * z0 + 3 * x[3] * z1 + 3 * x[2] * z2 + x[1] * z3;
+        const auto z4 = -x[4] * y0 - 3 * x[3] * y1 - 3 * x[2] * y2 - x[1] * y3;
+        CHECK(equalWithinAbs(sin(x), real4th({y0, y1, y2, y3, y4})));
+        CHECK(equalWithinAbs(cos(x), real4th({z0, z1, z2, z3, z4})));
+    }
 
-    y = sin(x);
-    z = cos(x);
-
-    CHECK_APPROX(y[0], sin(x[0]));
-    CHECK_APPROX(z[0], cos(x[0]));
-    CHECK_APPROX(y[1], x[1] * z[0]);
-    CHECK_APPROX(z[1], -x[1] * y[0]);
-    CHECK_APPROX(y[2], x[2] * z[0] + x[1] * z[1]);
-    CHECK_APPROX(z[2], -x[2] * y[0] - x[1] * y[1]);
-    CHECK_APPROX(y[3], x[3] * z[0] + 2 * x[2] * z[1] + x[1] * z[2]);
-    CHECK_APPROX(z[3], -x[3] * y[0] - 2 * x[2] * y[1] - x[1] * y[2]);
-    CHECK_APPROX(y[4], x[4] * z[0] + 3 * x[3] * z[1] + 3 * x[2] * z[2] + x[1] * z[3]);
-    CHECK_APPROX(z[4], -x[4] * y[0] - 3 * x[3] * y[1] - 3 * x[2] * y[2] - x[1] * y[3]);
-
-    y = tan(x);
-    z = sin(x) / cos(x);
-
-    CHECK_4TH_ORDER_REAL_NUMBERS(y, z);
+    SECTION("tan function")
+    {
+        CHECK(tan(real4th(1.234)) == real4th(std::tan(1.234)));
+        constexpr auto x = real4th({0.5, 3.0, -5.0, -15.0, 11.0});
+        CHECK(equalWithinAbs(tan(x), sin(x) / cos(x), 1e-13));
+    }
 
     //=====================================================================================================================
     //
     // TESTING INVERSE TRIGONOMETRIC FUNCTIONS
     //
     //=====================================================================================================================
+
+    real4th x, y, z, u, v, w;
+
+    x = {0.5, 3.0, -5.0, -15.0, 11.0};
+    y = -x;
+    z = y / 5.0;
 
     real4th xprime = {{x[1], x[2], x[3], x[4]}};
 

--- a/tests/forward/real/real.test.cpp
+++ b/tests/forward/real/real.test.cpp
@@ -149,12 +149,12 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
         constexpr auto x = real4th({1, -3, 5, -7, 11});
         constexpr auto y = real4th({0.5, 3.0, -5.0, -15.0, 11.0});
 
-        constexpr auto z = x * y;
-        CHECK_THAT(z[0], WithinAbs(x[0] * y[0], 1e-15));
-        CHECK_THAT(z[1], WithinAbs(x[1] * y[0] + x[0] * y[1], 1e-15));
-        CHECK_THAT(z[2], WithinAbs(x[2] * y[0] + 2 * x[1] * y[1] + x[0] * y[2], 1e-15));
-        CHECK_THAT(z[3], WithinAbs(x[3] * y[0] + 3 * x[2] * y[1] + 3 * x[1] * y[2] + x[0] * y[3], 1e-15));
-        CHECK_THAT(z[4], WithinAbs(x[4] * y[0] + 4 * x[3] * y[1] + 6 * x[2] * y[2] + 4 * x[1] * y[3] + x[0] * y[4], 1e-15));
+        constexpr auto z0 = x[0] * y[0];
+        constexpr auto z1 = x[1] * y[0] + x[0] * y[1];
+        constexpr auto z2 = x[2] * y[0] + 2 * x[1] * y[1] + x[0] * y[2];
+        constexpr auto z3 = x[3] * y[0] + 3 * x[2] * y[1] + 3 * x[1] * y[2] + x[0] * y[3];
+        constexpr auto z4 = x[4] * y[0] + 4 * x[3] * y[1] + 6 * x[2] * y[2] + 4 * x[1] * y[3] + x[0] * y[4];
+        CHECK(equalWithinAbs(x * y, real4th({z0, z1, z2, z3, z4})));
 
         CHECK(x * 3 == real4th({3, -9, 15, -21, 33}));
         CHECK(5 * x == real4th({5, -15, 25, -35, 55}));
@@ -168,22 +168,20 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
         constexpr auto y = real4th({0.5, 3.0, -5.0, -15.0, 11.0});
 
         // real / real
-        real4th z;
-        z[0] = x[0] / y[0];
-        z[1] = (x[1] - y[1] * z[0]) / y[0];
-        z[2] = (x[2] - y[2] * z[0] - 2 * y[1] * z[1]) / y[0];
-        z[3] = (x[3] - y[3] * z[0] - 3 * y[2] * z[1] - 3 * y[1] * z[2]) / y[0];
-        z[4] = (x[4] - y[4] * z[0] - 4 * y[3] * z[1] - 6 * y[2] * z[2] - 4 * y[1] * z[3]) / y[0];
-        CHECK(equalWithinAbs(x / y, std::move(z)));
+        constexpr auto z0 = x[0] / y[0];
+        constexpr auto z1 = (x[1] - y[1] * z0) / y[0];
+        constexpr auto z2 = (x[2] - y[2] * z0 - 2 * y[1] * z1) / y[0];
+        constexpr auto z3 = (x[3] - y[3] * z0 - 3 * y[2] * z1 - 3 * y[1] * z2) / y[0];
+        constexpr auto z4 = (x[4] - y[4] * z0 - 4 * y[3] * z1 - 6 * y[2] * z2 - 4 * y[1] * z3) / y[0];
+        CHECK(equalWithinAbs(x / y, real4th({z0, z1, z2, z3, z4})));
 
         // number / real
-        real4th a;
-        a[0] = 3.0 / y[0];
-        a[1] = -(y[1] * a[0]) / y[0];
-        a[2] = -(y[2] * a[0] + 2 * y[1] * a[1]) / y[0];
-        a[3] = -(y[3] * a[0] + 3 * y[2] * a[1] + 3 * y[1] * a[2]) / y[0];
-        a[4] = -(y[4] * a[0] + 4 * y[3] * a[1] + 6 * y[2] * a[2] + 4 * y[1] * a[3]) / y[0];
-        CHECK(equalWithinAbs(3 / y, std::move(a)));
+        constexpr auto a0 = 3.0 / y[0];
+        constexpr auto a1 = -(y[1] * a0) / y[0];
+        constexpr auto a2 = -(y[2] * a0 + 2 * y[1] * a1) / y[0];
+        constexpr auto a3 = -(y[3] * a0 + 3 * y[2] * a1 + 3 * y[1] * a2) / y[0];
+        constexpr auto a4 = -(y[4] * a0 + 4 * y[3] * a1 + 6 * y[2] * a2 + 4 * y[1] * a3) / y[0];
+        CHECK(equalWithinAbs(3 / y, real4th({a0, a1, a2, a3, a4})));
 
         // real / number
         CHECK(equalWithinAbs(y / 5, real4th({0.1, 0.6, -1.0, -3.0, 2.2})));

--- a/tests/forward/real/real.test.cpp
+++ b/tests/forward/real/real.test.cpp
@@ -155,9 +155,14 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
         constexpr auto x = real4th({1, -3, 5, -7, 11});
         constexpr auto y = real4th({0.5, 3.0, -5.0, -15.0, 11.0});
 
-        CHECK(x - y == real4th({0.5, -6.0, 10.0, 8.0, 0.0}));
-        CHECK(x - 1 == real4th({0, -3, 5, -7, 11}));
-        CHECK(1 - x == -(x - 1));
+        constexpr auto realSubReal = x - y;
+        CHECK(realSubReal == real4th({0.5, -6.0, 10.0, 8.0, 0.0}));
+
+        constexpr auto realSubNum = x - 1;
+        CHECK(realSubNum == real4th({0, -3, 5, -7, 11}));
+
+        constexpr auto numSubReal = 1 - x;
+        CHECK(numSubReal == -(x - 1));
     }
 
     SECTION("Multiplication")

--- a/tests/forward/real/real.test.cpp
+++ b/tests/forward/real/real.test.cpp
@@ -295,7 +295,7 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
     //
     //=====================================================================================================================
 
-    SECTION("sin/cos functions")
+    SECTION("sin, cos functions")
     {
         CHECK(sin(real4th(1.234)) == real4th(std::sin(1.234)));
         CHECK(cos(real4th(1.234)) == real4th(std::cos(1.234)));
@@ -322,85 +322,100 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
         CHECK(equalWithinAbs(tan(x), sin(x) / cos(x), 1e-13));
     }
 
-    //=====================================================================================================================
-    //
-    // TESTING INVERSE TRIGONOMETRIC FUNCTIONS
-    //
-    //=====================================================================================================================
+    SECTION("asin function")
+    {
+        CHECK(asin(real4th(0.1234)) == real4th(std::asin(0.1234)));
 
-    real4th x, y, z, u, v, w;
+        constexpr auto x = real4th({0.5, 3.0, -5.0, -15.0, 11.0});
+        constexpr auto xPrime = real3rd({x[1], x[2], x[3], x[4]});
+        const auto asinPrime = xPrime / sqrt(1 - real3rd(x) * real3rd(x));
+        real4th expected = asin(x[0]);
+        for(int i = 1; i < 5; ++i)
+            expected[i] = asinPrime[i - 1];
+        CHECK(equalWithinAbs(asin(x), expected, 1e-12));
+    }
 
-    x = {0.5, 3.0, -5.0, -15.0, 11.0};
-    y = -x;
-    z = y / 5.0;
+    SECTION("acos function")
+    {
+        CHECK(acos(real4th(0.1234)) == real4th(std::acos(0.1234)));
 
-    real4th xprime = {{x[1], x[2], x[3], x[4]}};
+        constexpr auto x = real4th({0.5, 3.0, -5.0, -15.0, 11.0});
+        constexpr auto xPrime = real3rd({x[1], x[2], x[3], x[4]});
+        const auto acosPrime = -xPrime / sqrt(1 - real3rd(x) * real3rd(x));
+        real4th expected = acos(x[0]);
+        for(int i = 1; i < 5; ++i)
+            expected[i] = acosPrime[i - 1];
+        CHECK(equalWithinAbs(acos(x), expected, 1e-12));
+    }
 
-    y = asin(x);
-    z = xprime / sqrt(1 - x * x);
+    SECTION("atan function")
+    {
+        CHECK(atan(real4th(1.234)) == real4th(std::atan(1.234)));
 
-    CHECK_APPROX(y[0], asin(x[0]));
-    CHECK_APPROX(y[1], z[0]);
-    CHECK_APPROX(y[2], z[1]);
-    CHECK_APPROX(y[3], z[2]);
-    CHECK_APPROX(y[4], z[3]);
+        constexpr auto x = real4th({0.5, 3.0, -5.0, -15.0, 11.0});
+        constexpr auto xPrime = real3rd({x[1], x[2], x[3], x[4]});
+        const auto atanPrime = xPrime / (1 + real3rd(x) * real3rd(x));
+        real4th expected = atan(x[0]);
+        for(int i = 1; i < 5; ++i)
+            expected[i] = atanPrime[i - 1];
+        CHECK(equalWithinAbs(atan(x), expected, 1e-12));
+    }
 
-    y = acos(x);
-    z = -xprime / sqrt(1 - x * x);
+    SECTION("atan2 functions")
+    {
+        CHECK(atan2(real4th(1.234), real4th(5.678)) == real4th(std::atan2(1.234, 5.678)));
 
-    CHECK_APPROX(y[0], acos(x[0]));
-    CHECK_APPROX(y[1], z[0]);
-    CHECK_APPROX(y[2], z[1]);
-    CHECK_APPROX(y[3], z[2]);
-    CHECK_APPROX(y[4], z[3]);
+        constexpr auto c = 2.0;
+        constexpr auto x = real4th({0.5, 3.0, -5.0, -15.0, 11.0});
+        constexpr auto xPrime = real3rd({x[1], x[2], x[3], x[4]});
 
-    y = atan(x);
-    z = xprime / (1 + x * x);
+        // atan2(double, real4th)
+        {
+            real4th expected = atan2(c, x[0]);
+            constexpr auto atan2Prime = xPrime * (-c / (c * c + real3rd(x) * real3rd(x)));
+            for(int i = 1; i < 5; ++i)
+                expected[i] = atan2Prime[i - 1];
+            CHECK(equalWithinAbs(atan2(c, x), expected, 1e-12));
+        }
 
-    CHECK_APPROX(y[0], atan(x[0]));
-    CHECK_APPROX(y[1], z[0]);
-    CHECK_APPROX(y[2], z[1]);
-    CHECK_APPROX(y[3], z[2]);
-    CHECK_APPROX(y[4], z[3]);
+        // atan2(real4th, double)
+        {
+            real4th expected = atan2(x[0], c);
+            constexpr auto atan2Prime = xPrime * (c / (c * c + real3rd(x) * real3rd(x)));
+            for(int i = 1; i < 5; ++i)
+                expected[i] = atan2Prime[i - 1];
+            CHECK(equalWithinAbs(atan2(x, c), expected, 1e-12));
+        }
 
-    // atan2(double, real4th)
-    constexpr double c = 2.0;
-    y = atan2(c, x);
-    z = xprime * (-c / (c * c + x * x));
+        // atan2(real4th, real4th)
+        {
+            constexpr auto y = real4th({1, -3, 5, -7, 11});
+            constexpr auto yPrime = real3rd({y[1], y[2], y[3], y[4]});
 
-    CHECK_APPROX(y[0], atan2(c, x[0]));
-    CHECK_APPROX(y[1], z[0]);
-    CHECK_APPROX(y[2], z[1]);
-    CHECK_APPROX(y[3], z[2]);
-    CHECK_APPROX(y[4], z[3]);
-
-    // atan2(real4th, double)
-    y = atan2(x, c);
-    z = xprime * (c / (c * c + x * x));
-
-    CHECK_APPROX(y[0], atan2(x[0], c));
-    CHECK_APPROX(y[1], z[0]);
-    CHECK_APPROX(y[2], z[1]);
-    CHECK_APPROX(y[3], z[2]);
-    CHECK_APPROX(y[4], z[3]);
-
-    // atan2(real4th, real4th)
-    real4th yprime = {{y[1], y[2], y[3], y[4]}};
-
-    const real4th s = atan2(y, x);
-    z = (x[0] * yprime - y[0] * xprime) / (x[0] * x[0] + y[0] * y[0]);
-
-    CHECK_APPROX(s[0], atan2(y[0], x[0]));
-    CHECK_APPROX(s[1], z[0]);
-    CHECK_APPROX(s[2], z[1]);
-    CHECK_APPROX(s[3], z[2]);
-    CHECK_APPROX(s[4], z[3]);
+            real4th expected = atan2(y[0], x[0]);
+            constexpr auto atan2Prime = (x[0] * yPrime - y[0] * xPrime) / (x[0] * x[0] + y[0] * y[0]);
+            for(int i = 1; i < 5; ++i)
+                expected[i] = atan2Prime[i - 1];
+            CHECK(equalWithinAbs(atan2(y, x), expected, 1e-12));
+        }
+    }
 
     //=====================================================================================================================
     //
     // TESTING HYPERBOLIC FUNCTIONS
     //
     //=====================================================================================================================
+
+    // const auto a = acos(x);
+    // const auto b = ;
+    // for(int i = 0; i < 5; ++i)
+    //     std::cout << a[i] << ' ' << b[i] << ' ' << a[i] - b[i] << '\n';
+    real4th x, y, z, u, v, w;
+
+    x = {0.5, 3.0, -5.0, -15.0, 11.0};
+    y = -x;
+    z = y / 5.0;
+
     y = sinh(x);
     z = cosh(x);
 

--- a/tests/forward/real/real.test.cpp
+++ b/tests/forward/real/real.test.cpp
@@ -43,7 +43,7 @@ using namespace autodiff;
     CHECK_APPROX(a[3], b[3]);              \
     CHECK_APPROX(a[4], b[4]);
 
-constexpr bool equalWithinAbs(real4th&& a, real4th&& b, const double tol = 1e-15)
+constexpr bool equalWithinAbs(const real4th a, const real4th b, const double tol = 1e-15)
 {
     for(int i = 0; i < 5; ++i)
         if(std::abs(a[i] - b[i]) > tol)
@@ -172,15 +172,19 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
         constexpr auto x = real4th({1, -3, 5, -7, 11});
         constexpr auto y = real4th({0.5, 3.0, -5.0, -15.0, 11.0});
 
+        constexpr auto realMulReal = x * y;
         constexpr auto z0 = x[0] * y[0];
         constexpr auto z1 = x[1] * y[0] + x[0] * y[1];
         constexpr auto z2 = x[2] * y[0] + 2 * x[1] * y[1] + x[0] * y[2];
         constexpr auto z3 = x[3] * y[0] + 3 * x[2] * y[1] + 3 * x[1] * y[2] + x[0] * y[3];
         constexpr auto z4 = x[4] * y[0] + 4 * x[3] * y[1] + 6 * x[2] * y[2] + 4 * x[1] * y[3] + x[0] * y[4];
-        CHECK(equalWithinAbs(x * y, real4th({z0, z1, z2, z3, z4})));
+        CHECK(equalWithinAbs(realMulReal, real4th({z0, z1, z2, z3, z4})));
 
-        CHECK(x * 3 == real4th({3, -9, 15, -21, 33}));
-        CHECK(5 * x == real4th({5, -15, 25, -35, 55}));
+        constexpr auto realMulNum = x * 3;
+        CHECK(realMulNum == real4th({3, -9, 15, -21, 33}));
+
+        constexpr auto numMulReal = 5 * x;
+        CHECK(numMulReal == real4th({5, -15, 25, -35, 55}));
     }
 
     SECTION("Division")

--- a/tests/forward/real/real.test.cpp
+++ b/tests/forward/real/real.test.cpp
@@ -194,24 +194,24 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
         constexpr auto x = real4th({1, -3, 5, -7, 11});
         constexpr auto y = real4th({0.5, 3.0, -5.0, -15.0, 11.0});
 
-        // real / real
+        constexpr auto realDivReal = x / y;
         constexpr auto z0 = x[0] / y[0];
         constexpr auto z1 = (x[1] - y[1] * z0) / y[0];
         constexpr auto z2 = (x[2] - y[2] * z0 - 2 * y[1] * z1) / y[0];
         constexpr auto z3 = (x[3] - y[3] * z0 - 3 * y[2] * z1 - 3 * y[1] * z2) / y[0];
         constexpr auto z4 = (x[4] - y[4] * z0 - 4 * y[3] * z1 - 6 * y[2] * z2 - 4 * y[1] * z3) / y[0];
-        CHECK(equalWithinAbs(x / y, real4th({z0, z1, z2, z3, z4})));
+        CHECK(equalWithinAbs(realDivReal, real4th({z0, z1, z2, z3, z4})));
 
-        // number / real
+        constexpr auto numDivReal = 3 / y;
         constexpr auto a0 = 3.0 / y[0];
         constexpr auto a1 = -(y[1] * a0) / y[0];
         constexpr auto a2 = -(y[2] * a0 + 2 * y[1] * a1) / y[0];
         constexpr auto a3 = -(y[3] * a0 + 3 * y[2] * a1 + 3 * y[1] * a2) / y[0];
         constexpr auto a4 = -(y[4] * a0 + 4 * y[3] * a1 + 6 * y[2] * a2 + 4 * y[1] * a3) / y[0];
-        CHECK(equalWithinAbs(3 / y, real4th({a0, a1, a2, a3, a4})));
+        CHECK(equalWithinAbs(numDivReal, real4th({a0, a1, a2, a3, a4})));
 
-        // real / number
-        CHECK(equalWithinAbs(y / 5, real4th({0.1, 0.6, -1.0, -3.0, 2.2})));
+        constexpr auto realDivNum = y / 5;
+        CHECK(equalWithinAbs(realDivNum, real4th({0.1, 0.6, -1.0, -3.0, 2.2})));
     }
 
     //=====================================================================================================================

--- a/tests/forward/real/real.test.cpp
+++ b/tests/forward/real/real.test.cpp
@@ -140,9 +140,14 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
         constexpr auto x = real4th({1, -3, 5, -7, 11});
         constexpr auto y = real4th({0.5, 3.0, -5.0, -15.0, 11.0});
 
-        CHECK(x + y == real4th({1.5, 0.0, 0.0, -22.0, 22.0}));
-        CHECK(x + 1 == real4th({2, -3, 5, -7, 11}));
-        CHECK(1 + x == x + 1);
+        constexpr auto realAddReal = x + y;
+        CHECK(realAddReal == real4th({1.5, 0.0, 0.0, -22.0, 22.0}));
+
+        constexpr auto realAddNum = x + 1;
+        CHECK(realAddNum == real4th({2, -3, 5, -7, 11}));
+
+        constexpr auto numAddReal = 1 + x;
+        CHECK(numAddReal == x + 1);
     }
 
     SECTION("Subtraction")

--- a/tests/forward/real/real.test.cpp
+++ b/tests/forward/real/real.test.cpp
@@ -105,6 +105,8 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
         }
     }
 
+    // explicitly tested ctor + equality comparison -> now we can trust checks by equality comparisons of temporaries
+
     SECTION("Assignments")
     {
         real4th x, y;
@@ -120,6 +122,17 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
 
         y = -x;
         CHECK(y == -x);
+    }
+
+    SECTION("Unary plus/minus")
+    {
+        constexpr auto x = real4th({1, -3, 5, -7, 11});
+
+        constexpr auto plusX = +x;
+        CHECK(plusX == x);
+
+        constexpr auto minusX = -x;
+        CHECK(minusX == real4th({-1, 3, -5, 7, -11}));
     }
 
     SECTION("Addition")

--- a/tests/forward/real/real.test.cpp
+++ b/tests/forward/real/real.test.cpp
@@ -77,6 +77,8 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
 {
     SECTION("Constructors")
     {
+        constexpr auto tmp = real4th();
+
         constexpr auto x = real4th(2);
         CHECK(x[0] == 2);
         CHECK(x[1] == 0);
@@ -85,12 +87,17 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
         CHECK(x[4] == 0);
 
         constexpr auto y = real4th({1, -3, 5, -7, 11});
-
         CHECK(y[0] == 1);
         CHECK(y[1] == -3);
         CHECK(y[2] == 5);
         CHECK(y[3] == -7);
         CHECK(y[4] == 11);
+
+        constexpr auto z = real3rd(Real<4, float>({1, -3, 5, -7, 11}));
+        CHECK(z[0] == 1);
+        CHECK(z[1] == -3);
+        CHECK(z[2] == 5);
+        CHECK(z[3] == -7);
     }
 
     SECTION("Equality Comparison")

--- a/tests/forward/real/real.test.cpp
+++ b/tests/forward/real/real.test.cpp
@@ -35,6 +35,7 @@
 #include <cmath>
 #include <functional>
 #include <tests/utils/catch.hpp>
+#include <vector>
 
 using namespace autodiff;
 
@@ -52,24 +53,6 @@ constexpr bool equalWithinAbs(const real4th a, const real4th b, const double tol
             return false;
     return true;
 }
-
-#define CHECK_DERIVATIVES_REAL4TH_WRT(expr)                                          \
-    {                                                                                \
-        real4th x = 5, y = 7;                                                        \
-        auto f = [](const real4th& x, const real4th& y) -> real4th { return expr; }; \
-        /* Check directional derivatives of f(x,y) along direction (3, 5) */         \
-        auto dfdv = derivatives(f, along(3, 5), at(x, y));                           \
-        x[1] = 3.0;                                                                  \
-        y[1] = 5.0;                                                                  \
-        u = expr;                                                                    \
-        x[1] = 0.0;                                                                  \
-        y[1] = 0.0;                                                                  \
-        CHECK_APPROX(dfdv[0], u[0]);                                                 \
-        CHECK_APPROX(dfdv[1], u[1]);                                                 \
-        CHECK_APPROX(dfdv[2], u[2]);                                                 \
-        CHECK_APPROX(dfdv[3], u[3]);                                                 \
-        CHECK_APPROX(dfdv[4], u[4]);                                                 \
-    }
 
 // Auxiliary constants
 constexpr auto ln10 = 2.302585092994046;
@@ -716,57 +699,55 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
     //
     //=====================================================================================================================
 
-    // const auto a = acos(x);
-    // const auto b = ;
-    // for(int i = 0; i < 5; ++i)
-    //     std::cout << a[i] << ' ' << b[i] << ' ' << a[i] - b[i] << '\n';
-    real4th x, y, z, u, v, w;
-
-    x = {0.5, 3.0, -5.0, -15.0, 11.0};
-    y = -x;
-    z = y / 5.0;
-
-    CHECK_DERIVATIVES_REAL4TH_WRT(exp(log(2 * x + 3 * y)));
-    CHECK_DERIVATIVES_REAL4TH_WRT(sin(2 * x + 3 * y));
-    CHECK_DERIVATIVES_REAL4TH_WRT(exp(2 * x + 3 * y) * log(x / y));
-
-    // Testing array-unpacking of derivatives for real number
+    SECTION("directional derivative of f(x,y)=exp(log(2*x+3*y))")
     {
-        real4th x = {{2.0, 3.0, 4.0, 5.0, 6.0}};
+        constexpr auto x0 = 5, y0 = 7, x1 = 3, y1 = 5;
+        const auto f = [](const real4th& x, const real4th& y) -> real4th { return exp(log(2 * x + 3 * y)); };
 
-        auto [x0, x1, x2, x3, x4] = derivatives(x);
-
-        CHECK_APPROX(x0, x[0]);
-        CHECK_APPROX(x1, x[1]);
-        CHECK_APPROX(x2, x[2]);
-        CHECK_APPROX(x3, x[3]);
-        CHECK_APPROX(x4, x[4]);
+        const auto dfdv = derivatives(f, along(x1, y1), at(real4th(x0), real4th(y0)));
+        const auto u = f(real4th({x0, x1, 0, 0, 0}), real4th({y0, y1, 0, 0, 0}));
+        CHECK(equalWithinAbs(u, dfdv, 1e-12));
     }
 
-    // Testing array-unpacking of derivatives for vector of real numbers
+    SECTION("directional derivative of f(x,y)=sin(2*x+3*y)")
     {
-        real4th x = {{2.0, 3.0, 4.0, 5.0, 6.0}};
-        real4th y = {{3.0, 4.0, 5.0, 6.0, 7.0}};
-        real4th z = {{4.0, 5.0, 6.0, 7.0, 8.0}};
+        constexpr auto x0 = 5, y0 = 7, x1 = 3, y1 = 5;
+        const auto f = [](const real4th& x, const real4th& y) -> real4th { return sin(2 * x + 3 * y); };
 
-        std::vector<real4th> u = {x, y, z};
+        const auto dfdv = derivatives(f, along(x1, y1), at(real4th(x0), real4th(y0)));
+        const auto u = f(real4th({x0, x1, 0, 0, 0}), real4th({y0, y1, 0, 0, 0}));
+        CHECK(equalWithinAbs(u, dfdv, 1e-12));
+    }
 
-        auto [u0, u1, u2, u3, u4] = derivatives(u);
+    SECTION("directional derivative of f(x,y)=exp(2*x+3*y)*log(x/y)")
+    {
+        constexpr auto x0 = 5, y0 = 7, x1 = 3, y1 = 5;
+        const auto f = [](const real4th& x, const real4th& y) -> real4th { return exp(2 * x + 3 * y) * log(x / y); };
 
-        CHECK_APPROX(u0[0], x[0]);
-        CHECK_APPROX(u1[0], x[1]);
-        CHECK_APPROX(u2[0], x[2]);
-        CHECK_APPROX(u3[0], x[3]);
-        CHECK_APPROX(u4[0], x[4]);
-        CHECK_APPROX(u0[1], y[0]);
-        CHECK_APPROX(u1[1], y[1]);
-        CHECK_APPROX(u2[1], y[2]);
-        CHECK_APPROX(u3[1], y[3]);
-        CHECK_APPROX(u4[1], y[4]);
-        CHECK_APPROX(u0[2], z[0]);
-        CHECK_APPROX(u1[2], z[1]);
-        CHECK_APPROX(u2[2], z[2]);
-        CHECK_APPROX(u3[2], z[3]);
-        CHECK_APPROX(u4[2], z[4]);
+        const auto dfdv = derivatives(f, along(x1, y1), at(real4th(x0), real4th(y0)));
+        const auto u = f(real4th({x0, x1, 0, 0, 0}), real4th({y0, y1, 0, 0, 0}));
+        CHECK(equalWithinAbs(u, dfdv, 1e-12));
+    }
+
+    SECTION("Testing array-unpacking of derivatives for real number")
+    {
+        constexpr auto x = real4th({2.0, 3.0, 4.0, 5.0, 6.0});
+
+        const auto [x0, x1, x2, x3, x4] = derivatives(x);
+        CHECK(x == real4th({x0, x1, x2, x3, x4}));
+    }
+
+    SECTION("Testing array-unpacking of derivatives for vector of real numbers")
+    {
+        constexpr auto x = real4th({2.0, 3.0, 4.0, 5.0, 6.0});
+        constexpr auto y = real4th({3.0, 4.0, 5.0, 6.0, 7.0});
+        constexpr auto z = real4th({4.0, 5.0, 6.0, 7.0, 8.0});
+
+        const auto u = std::vector{x, y, z};
+
+        const auto [u0, u1, u2, u3, u4] = derivatives(u);
+
+        for(int i = 0; i < 3; ++i)
+            CHECK(u[i] == real4th({u0[i], u1[i], u2[i], u3[i], u4[i]}));
     }
 }

--- a/tests/forward/real/real.test.cpp
+++ b/tests/forward/real/real.test.cpp
@@ -32,27 +32,30 @@
 #include <tests/utils/catch.hpp>
 using namespace autodiff;
 
-
 #define CHECK_4TH_ORDER_REAL_NUMBERS(a, b) \
-    CHECK_APPROX( a[0], b[0] );            \
-    CHECK_APPROX( a[1], b[1] );            \
-    CHECK_APPROX( a[2], b[2] );            \
-    CHECK_APPROX( a[3], b[3] );            \
-    CHECK_APPROX( a[4], b[4] );            \
+    CHECK_APPROX(a[0], b[0]);              \
+    CHECK_APPROX(a[1], b[1]);              \
+    CHECK_APPROX(a[2], b[2]);              \
+    CHECK_APPROX(a[3], b[3]);              \
+    CHECK_APPROX(a[4], b[4]);
 
-#define CHECK_DERIVATIVES_REAL4TH_WRT(expr)                                       \
-{                                                                                 \
-    real4th x = 5, y = 7;                                                         \
-    auto f = [](const real4th& x, const real4th& y) -> real4th { return expr; };  \
-    /* Check directional derivatives of f(x,y) along direction (3, 5) */          \
-    auto dfdv = derivatives(f, along(3, 5), at(x, y));                            \
-    x[1] = 3.0; y[1] = 5.0; u = expr; x[1] = 0.0; y[1] = 0.0;                     \
-    CHECK_APPROX( dfdv[0], u[0] );                                                \
-    CHECK_APPROX( dfdv[1], u[1] );                                                \
-    CHECK_APPROX( dfdv[2], u[2] );                                                \
-    CHECK_APPROX( dfdv[3], u[3] );                                                \
-    CHECK_APPROX( dfdv[4], u[4] );                                                \
-}
+#define CHECK_DERIVATIVES_REAL4TH_WRT(expr)                                          \
+    {                                                                                \
+        real4th x = 5, y = 7;                                                        \
+        auto f = [](const real4th& x, const real4th& y) -> real4th { return expr; }; \
+        /* Check directional derivatives of f(x,y) along direction (3, 5) */         \
+        auto dfdv = derivatives(f, along(3, 5), at(x, y));                           \
+        x[1] = 3.0;                                                                  \
+        y[1] = 5.0;                                                                  \
+        u = expr;                                                                    \
+        x[1] = 0.0;                                                                  \
+        y[1] = 0.0;                                                                  \
+        CHECK_APPROX(dfdv[0], u[0]);                                                 \
+        CHECK_APPROX(dfdv[1], u[1]);                                                 \
+        CHECK_APPROX(dfdv[2], u[2]);                                                 \
+        CHECK_APPROX(dfdv[3], u[3]);                                                 \
+        CHECK_APPROX(dfdv[4], u[4]);                                                 \
+    }
 
 // Auxiliary constants
 const auto ln10 = 2.302585092994046;
@@ -64,131 +67,131 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
 
     x = 1.0;
 
-    CHECK_APPROX( x[0],  1.0 );
-    CHECK_APPROX( x[1],  0.0 );
-    CHECK_APPROX( x[2],  0.0 );
-    CHECK_APPROX( x[3],  0.0 );
-    CHECK_APPROX( x[4],  0.0 );
+    CHECK_APPROX(x[0], 1.0);
+    CHECK_APPROX(x[1], 0.0);
+    CHECK_APPROX(x[2], 0.0);
+    CHECK_APPROX(x[3], 0.0);
+    CHECK_APPROX(x[4], 0.0);
 
     x = {0.5, 3.0, -5.0, -15.0, 11.0};
 
-    CHECK_APPROX( x[0],   0.5 );
-    CHECK_APPROX( x[1],   3.0 );
-    CHECK_APPROX( x[2],  -5.0 );
-    CHECK_APPROX( x[3], -15.0 );
-    CHECK_APPROX( x[4],  11.0 );
+    CHECK_APPROX(x[0], 0.5);
+    CHECK_APPROX(x[1], 3.0);
+    CHECK_APPROX(x[2], -5.0);
+    CHECK_APPROX(x[3], -15.0);
+    CHECK_APPROX(x[4], 11.0);
 
     y = +x;
 
-    CHECK_APPROX( y[0],  x[0] );
-    CHECK_APPROX( y[1],  x[1] );
-    CHECK_APPROX( y[2],  x[2] );
-    CHECK_APPROX( y[3],  x[3] );
-    CHECK_APPROX( y[4],  x[4] );
+    CHECK_APPROX(y[0], x[0]);
+    CHECK_APPROX(y[1], x[1]);
+    CHECK_APPROX(y[2], x[2]);
+    CHECK_APPROX(y[3], x[3]);
+    CHECK_APPROX(y[4], x[4]);
 
     y = -x;
 
-    CHECK_APPROX( y[0],  -x[0] );
-    CHECK_APPROX( y[1],  -x[1] );
-    CHECK_APPROX( y[2],  -x[2] );
-    CHECK_APPROX( y[3],  -x[3] );
-    CHECK_APPROX( y[4],  -x[4] );
+    CHECK_APPROX(y[0], -x[0]);
+    CHECK_APPROX(y[1], -x[1]);
+    CHECK_APPROX(y[2], -x[2]);
+    CHECK_APPROX(y[3], -x[3]);
+    CHECK_APPROX(y[4], -x[4]);
 
     z = x + y;
 
-    CHECK_APPROX( z[0],  x[0] + y[0] );
-    CHECK_APPROX( z[1],  x[1] + y[1] );
-    CHECK_APPROX( z[2],  x[2] + y[2] );
-    CHECK_APPROX( z[3],  x[3] + y[3] );
-    CHECK_APPROX( z[4],  x[4] + y[4] );
+    CHECK_APPROX(z[0], x[0] + y[0]);
+    CHECK_APPROX(z[1], x[1] + y[1]);
+    CHECK_APPROX(z[2], x[2] + y[2]);
+    CHECK_APPROX(z[3], x[3] + y[3]);
+    CHECK_APPROX(z[4], x[4] + y[4]);
 
     z = x + 1.0;
 
-    CHECK_APPROX( z[0],  x[0] + 1.0 );
-    CHECK_APPROX( z[1],  x[1] );
-    CHECK_APPROX( z[2],  x[2] );
-    CHECK_APPROX( z[3],  x[3] );
-    CHECK_APPROX( z[4],  x[4] );
+    CHECK_APPROX(z[0], x[0] + 1.0);
+    CHECK_APPROX(z[1], x[1]);
+    CHECK_APPROX(z[2], x[2]);
+    CHECK_APPROX(z[3], x[3]);
+    CHECK_APPROX(z[4], x[4]);
 
     z = 1.0 + x;
 
-    CHECK_APPROX( z[0],  x[0] + 1.0 );
-    CHECK_APPROX( z[1],  x[1] );
-    CHECK_APPROX( z[2],  x[2] );
-    CHECK_APPROX( z[3],  x[3] );
-    CHECK_APPROX( z[4],  x[4] );
+    CHECK_APPROX(z[0], x[0] + 1.0);
+    CHECK_APPROX(z[1], x[1]);
+    CHECK_APPROX(z[2], x[2]);
+    CHECK_APPROX(z[3], x[3]);
+    CHECK_APPROX(z[4], x[4]);
 
     z = x - y;
 
-    CHECK_APPROX( z[0],  x[0] - y[0] );
-    CHECK_APPROX( z[1],  x[1] - y[1] );
-    CHECK_APPROX( z[2],  x[2] - y[2] );
-    CHECK_APPROX( z[3],  x[3] - y[3] );
-    CHECK_APPROX( z[4],  x[4] - y[4] );
+    CHECK_APPROX(z[0], x[0] - y[0]);
+    CHECK_APPROX(z[1], x[1] - y[1]);
+    CHECK_APPROX(z[2], x[2] - y[2]);
+    CHECK_APPROX(z[3], x[3] - y[3]);
+    CHECK_APPROX(z[4], x[4] - y[4]);
 
     z = x - 1.0;
 
-    CHECK_APPROX( z[0],  x[0] - 1.0 );
-    CHECK_APPROX( z[1],  x[1] );
-    CHECK_APPROX( z[2],  x[2] );
-    CHECK_APPROX( z[3],  x[3] );
-    CHECK_APPROX( z[4],  x[4] );
+    CHECK_APPROX(z[0], x[0] - 1.0);
+    CHECK_APPROX(z[1], x[1]);
+    CHECK_APPROX(z[2], x[2]);
+    CHECK_APPROX(z[3], x[3]);
+    CHECK_APPROX(z[4], x[4]);
 
     z = 1.0 - x;
 
-    CHECK_APPROX( z[0],  1.0 - x[0] );
-    CHECK_APPROX( z[1],  -x[1] );
-    CHECK_APPROX( z[2],  -x[2] );
-    CHECK_APPROX( z[3],  -x[3] );
-    CHECK_APPROX( z[4],  -x[4] );
+    CHECK_APPROX(z[0], 1.0 - x[0]);
+    CHECK_APPROX(z[1], -x[1]);
+    CHECK_APPROX(z[2], -x[2]);
+    CHECK_APPROX(z[3], -x[3]);
+    CHECK_APPROX(z[4], -x[4]);
 
     z = x * y;
 
-    CHECK_APPROX( z[0],  x[0]*y[0] );
-    CHECK_APPROX( z[1],  x[1]*y[0] + x[0]*y[1] );
-    CHECK_APPROX( z[2],  x[2]*y[0] + 2*x[1]*y[1] + x[0]*y[2] );
-    CHECK_APPROX( z[3],  x[3]*y[0] + 3*x[2]*y[1] + 3*x[1]*y[2] + x[0]*y[3] );
-    CHECK_APPROX( z[4],  x[4]*y[0] + 4*x[3]*y[1] + 6*x[2]*y[2] + 4*x[1]*y[3] + x[0]*y[4] );
+    CHECK_APPROX(z[0], x[0] * y[0]);
+    CHECK_APPROX(z[1], x[1] * y[0] + x[0] * y[1]);
+    CHECK_APPROX(z[2], x[2] * y[0] + 2 * x[1] * y[1] + x[0] * y[2]);
+    CHECK_APPROX(z[3], x[3] * y[0] + 3 * x[2] * y[1] + 3 * x[1] * y[2] + x[0] * y[3]);
+    CHECK_APPROX(z[4], x[4] * y[0] + 4 * x[3] * y[1] + 6 * x[2] * y[2] + 4 * x[1] * y[3] + x[0] * y[4]);
 
     z = x * 3.0;
 
-    CHECK_APPROX( z[0],  x[0]*3.0 );
-    CHECK_APPROX( z[1],  x[1]*3.0 );
-    CHECK_APPROX( z[2],  x[2]*3.0 );
-    CHECK_APPROX( z[3],  x[3]*3.0 );
-    CHECK_APPROX( z[4],  x[4]*3.0 );
+    CHECK_APPROX(z[0], x[0] * 3.0);
+    CHECK_APPROX(z[1], x[1] * 3.0);
+    CHECK_APPROX(z[2], x[2] * 3.0);
+    CHECK_APPROX(z[3], x[3] * 3.0);
+    CHECK_APPROX(z[4], x[4] * 3.0);
 
     z = 5.0 * x;
 
-    CHECK_APPROX( z[0],  5.0*x[0] );
-    CHECK_APPROX( z[1],  5.0*x[1] );
-    CHECK_APPROX( z[2],  5.0*x[2] );
-    CHECK_APPROX( z[3],  5.0*x[3] );
-    CHECK_APPROX( z[4],  5.0*x[4] );
+    CHECK_APPROX(z[0], 5.0 * x[0]);
+    CHECK_APPROX(z[1], 5.0 * x[1]);
+    CHECK_APPROX(z[2], 5.0 * x[2]);
+    CHECK_APPROX(z[3], 5.0 * x[3]);
+    CHECK_APPROX(z[4], 5.0 * x[4]);
 
     z = x / y;
 
-    CHECK_APPROX( z[0],  (x[0])/y[0] );
-    CHECK_APPROX( z[1],  (x[1] - y[1]*z[0])/y[0] );
-    CHECK_APPROX( z[2],  (x[2] - y[2]*z[0] - 2*y[1]*z[1])/y[0] );
-    CHECK_APPROX( z[3],  (x[3] - y[3]*z[0] - 3*y[2]*z[1] - 3*y[1]*z[2])/y[0] );
-    CHECK_APPROX( z[4],  (x[4] - y[4]*z[0] - 4*y[3]*z[1] - 6*y[2]*z[2] - 4*y[1]*z[3])/y[0] );
+    CHECK_APPROX(z[0], (x[0]) / y[0]);
+    CHECK_APPROX(z[1], (x[1] - y[1] * z[0]) / y[0]);
+    CHECK_APPROX(z[2], (x[2] - y[2] * z[0] - 2 * y[1] * z[1]) / y[0]);
+    CHECK_APPROX(z[3], (x[3] - y[3] * z[0] - 3 * y[2] * z[1] - 3 * y[1] * z[2]) / y[0]);
+    CHECK_APPROX(z[4], (x[4] - y[4] * z[0] - 4 * y[3] * z[1] - 6 * y[2] * z[2] - 4 * y[1] * z[3]) / y[0]);
 
     z = 3.0 / y;
 
-    CHECK_APPROX( z[0],  3.0/y[0] );
-    CHECK_APPROX( z[1],  -(y[1]*z[0])/y[0] );
-    CHECK_APPROX( z[2],  -(y[2]*z[0] + 2*y[1]*z[1])/y[0] );
-    CHECK_APPROX( z[3],  -(y[3]*z[0] + 3*y[2]*z[1] + 3*y[1]*z[2])/y[0] );
-    CHECK_APPROX( z[4],  -(y[4]*z[0] + 4*y[3]*z[1] + 6*y[2]*z[2] + 4*y[1]*z[3])/y[0] );
+    CHECK_APPROX(z[0], 3.0 / y[0]);
+    CHECK_APPROX(z[1], -(y[1] * z[0]) / y[0]);
+    CHECK_APPROX(z[2], -(y[2] * z[0] + 2 * y[1] * z[1]) / y[0]);
+    CHECK_APPROX(z[3], -(y[3] * z[0] + 3 * y[2] * z[1] + 3 * y[1] * z[2]) / y[0]);
+    CHECK_APPROX(z[4], -(y[4] * z[0] + 4 * y[3] * z[1] + 6 * y[2] * z[2] + 4 * y[1] * z[3]) / y[0]);
 
     z = y / 5.0;
 
-    CHECK_APPROX( z[0],  y[0] / 5.0 );
-    CHECK_APPROX( z[1],  y[1] / 5.0 );
-    CHECK_APPROX( z[2],  y[2] / 5.0 );
-    CHECK_APPROX( z[3],  y[3] / 5.0 );
-    CHECK_APPROX( z[4],  y[4] / 5.0 );
+    CHECK_APPROX(z[0], y[0] / 5.0);
+    CHECK_APPROX(z[1], y[1] / 5.0);
+    CHECK_APPROX(z[2], y[2] / 5.0);
+    CHECK_APPROX(z[3], y[3] / 5.0);
+    CHECK_APPROX(z[4], y[4] / 5.0);
 
     //=====================================================================================================================
     //
@@ -198,22 +201,22 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
 
     y = exp(x);
 
-    CHECK_APPROX( y[0], exp(x[0]) );
-    CHECK_APPROX( y[1], x[1] * y[0] );
-    CHECK_APPROX( y[2], x[2] * y[0] + x[1] * y[1] );
-    CHECK_APPROX( y[3], x[3] * y[0] + 2*x[2] * y[1] + x[1] * y[2] );
-    CHECK_APPROX( y[4], x[4] * y[0] + 3*x[3] * y[1] + 3*x[2] * y[2] + x[1] * y[3] );
+    CHECK_APPROX(y[0], exp(x[0]));
+    CHECK_APPROX(y[1], x[1] * y[0]);
+    CHECK_APPROX(y[2], x[2] * y[0] + x[1] * y[1]);
+    CHECK_APPROX(y[3], x[3] * y[0] + 2 * x[2] * y[1] + x[1] * y[2]);
+    CHECK_APPROX(y[4], x[4] * y[0] + 3 * x[3] * y[1] + 3 * x[2] * y[2] + x[1] * y[3]);
 
     y = log(x);
 
-    CHECK_APPROX( y[0], log(x[0]) );
-    CHECK_APPROX( y[1], (x[1]) / x[0] );
-    CHECK_APPROX( y[2], (x[2] - x[1]*y[1]) / x[0] );
-    CHECK_APPROX( y[3], (x[3] - x[2]*y[1] - 2*x[1]*y[2]) / x[0] );
-    CHECK_APPROX( y[4], (x[4] - x[3]*y[1] - 3*x[2]*y[2] - 3*x[1]*y[3]) / x[0] );
+    CHECK_APPROX(y[0], log(x[0]));
+    CHECK_APPROX(y[1], (x[1]) / x[0]);
+    CHECK_APPROX(y[2], (x[2] - x[1] * y[1]) / x[0]);
+    CHECK_APPROX(y[3], (x[3] - x[2] * y[1] - 2 * x[1] * y[2]) / x[0]);
+    CHECK_APPROX(y[4], (x[4] - x[3] * y[1] - 3 * x[2] * y[2] - 3 * x[1] * y[3]) / x[0]);
 
     y = log10(x);
-    z = log(x)/ln10;
+    z = log(x) / ln10;
 
     CHECK_4TH_ORDER_REAL_NUMBERS(y, z);
 
@@ -223,7 +226,7 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
     CHECK_4TH_ORDER_REAL_NUMBERS(y, z);
 
     y = cbrt(x);
-    z = exp(1.0/3.0 * log(x));
+    z = exp(1.0 / 3.0 * log(x));
 
     CHECK_4TH_ORDER_REAL_NUMBERS(y, z);
 
@@ -251,19 +254,19 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
     y = sin(x);
     z = cos(x);
 
-    CHECK_APPROX( y[0],  sin(x[0]) );
-    CHECK_APPROX( z[0],  cos(x[0]) );
-    CHECK_APPROX( y[1],   x[1] * z[0] );
-    CHECK_APPROX( z[1],  -x[1] * y[0] );
-    CHECK_APPROX( y[2],   x[2] * z[0] + x[1] * z[1] );
-    CHECK_APPROX( z[2],  -x[2] * y[0] - x[1] * y[1] );
-    CHECK_APPROX( y[3],   x[3] * z[0] + 2*x[2] * z[1] + x[1] * z[2] );
-    CHECK_APPROX( z[3],  -x[3] * y[0] - 2*x[2] * y[1] - x[1] * y[2] );
-    CHECK_APPROX( y[4],   x[4] * z[0] + 3*x[3] * z[1] + 3*x[2] * z[2] + x[1] * z[3] );
-    CHECK_APPROX( z[4],  -x[4] * y[0] - 3*x[3] * y[1] - 3*x[2] * y[2] - x[1] * y[3] );
+    CHECK_APPROX(y[0], sin(x[0]));
+    CHECK_APPROX(z[0], cos(x[0]));
+    CHECK_APPROX(y[1], x[1] * z[0]);
+    CHECK_APPROX(z[1], -x[1] * y[0]);
+    CHECK_APPROX(y[2], x[2] * z[0] + x[1] * z[1]);
+    CHECK_APPROX(z[2], -x[2] * y[0] - x[1] * y[1]);
+    CHECK_APPROX(y[3], x[3] * z[0] + 2 * x[2] * z[1] + x[1] * z[2]);
+    CHECK_APPROX(z[3], -x[3] * y[0] - 2 * x[2] * y[1] - x[1] * y[2]);
+    CHECK_APPROX(y[4], x[4] * z[0] + 3 * x[3] * z[1] + 3 * x[2] * z[2] + x[1] * z[3]);
+    CHECK_APPROX(z[4], -x[4] * y[0] - 3 * x[3] * y[1] - 3 * x[2] * y[2] - x[1] * y[3]);
 
     y = tan(x);
-    z = sin(x)/cos(x);
+    z = sin(x) / cos(x);
 
     CHECK_4TH_ORDER_REAL_NUMBERS(y, z);
 
@@ -273,34 +276,34 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
     //
     //=====================================================================================================================
 
-    real4th xprime = {{ x[1], x[2], x[3], x[4] }};
+    real4th xprime = {{x[1], x[2], x[3], x[4]}};
 
     y = asin(x);
-    z = xprime/sqrt(1 - x*x);
+    z = xprime / sqrt(1 - x * x);
 
-    CHECK_APPROX( y[0], asin(x[0]) );
-    CHECK_APPROX( y[1], z[0] );
-    CHECK_APPROX( y[2], z[1] );
-    CHECK_APPROX( y[3], z[2] );
-    CHECK_APPROX( y[4], z[3] );
+    CHECK_APPROX(y[0], asin(x[0]));
+    CHECK_APPROX(y[1], z[0]);
+    CHECK_APPROX(y[2], z[1]);
+    CHECK_APPROX(y[3], z[2]);
+    CHECK_APPROX(y[4], z[3]);
 
     y = acos(x);
-    z = -xprime/sqrt(1 - x*x);
+    z = -xprime / sqrt(1 - x * x);
 
-    CHECK_APPROX( y[0], acos(x[0]) );
-    CHECK_APPROX( y[1], z[0] );
-    CHECK_APPROX( y[2], z[1] );
-    CHECK_APPROX( y[3], z[2] );
-    CHECK_APPROX( y[4], z[3] );
+    CHECK_APPROX(y[0], acos(x[0]));
+    CHECK_APPROX(y[1], z[0]);
+    CHECK_APPROX(y[2], z[1]);
+    CHECK_APPROX(y[3], z[2]);
+    CHECK_APPROX(y[4], z[3]);
 
     y = atan(x);
-    z = xprime/(1 + x*x);
+    z = xprime / (1 + x * x);
 
-    CHECK_APPROX( y[0], atan(x[0]) );
-    CHECK_APPROX( y[1], z[0] );
-    CHECK_APPROX( y[2], z[1] );
-    CHECK_APPROX( y[3], z[2] );
-    CHECK_APPROX( y[4], z[3] );
+    CHECK_APPROX(y[0], atan(x[0]));
+    CHECK_APPROX(y[1], z[0]);
+    CHECK_APPROX(y[2], z[1]);
+    CHECK_APPROX(y[3], z[2]);
+    CHECK_APPROX(y[4], z[3]);
 
     // atan2(double, real4th)
     constexpr double c = 2.0;
@@ -324,9 +327,9 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
     CHECK_APPROX(y[4], z[3]);
 
     // atan2(real4th, real4th)
-    real4th yprime = {{ y[1], y[2], y[3], y[4] }};
+    real4th yprime = {{y[1], y[2], y[3], y[4]}};
 
-    const real4th s = atan2(y,x);
+    const real4th s = atan2(y, x);
     z = (x[0] * yprime - y[0] * xprime) / (x[0] * x[0] + y[0] * y[0]);
 
     CHECK_APPROX(s[0], atan2(y[0], x[0]));
@@ -343,48 +346,48 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
     y = sinh(x);
     z = cosh(x);
 
-    CHECK_APPROX( y[0],  sinh(x[0]) );
-    CHECK_APPROX( z[0],  cosh(x[0]) );
-    CHECK_APPROX( y[1],  x[1] * z[0] );
-    CHECK_APPROX( z[1],  x[1] * y[0] );
-    CHECK_APPROX( y[2],  x[2] * z[0] + x[1] * z[1] );
-    CHECK_APPROX( z[2],  x[2] * y[0] + x[1] * y[1] );
-    CHECK_APPROX( y[3],  x[3] * z[0] + 2*x[2] * z[1] + x[1] * z[2] );
-    CHECK_APPROX( z[3],  x[3] * y[0] + 2*x[2] * y[1] + x[1] * y[2] );
-    CHECK_APPROX( y[4],  x[4] * z[0] + 3*x[3] * z[1] + 3*x[2] * z[2] + x[1] * z[3] );
-    CHECK_APPROX( z[4],  x[4] * y[0] + 3*x[3] * y[1] + 3*x[2] * y[2] + x[1] * y[3] );
+    CHECK_APPROX(y[0], sinh(x[0]));
+    CHECK_APPROX(z[0], cosh(x[0]));
+    CHECK_APPROX(y[1], x[1] * z[0]);
+    CHECK_APPROX(z[1], x[1] * y[0]);
+    CHECK_APPROX(y[2], x[2] * z[0] + x[1] * z[1]);
+    CHECK_APPROX(z[2], x[2] * y[0] + x[1] * y[1]);
+    CHECK_APPROX(y[3], x[3] * z[0] + 2 * x[2] * z[1] + x[1] * z[2]);
+    CHECK_APPROX(z[3], x[3] * y[0] + 2 * x[2] * y[1] + x[1] * y[2]);
+    CHECK_APPROX(y[4], x[4] * z[0] + 3 * x[3] * z[1] + 3 * x[2] * z[2] + x[1] * z[3]);
+    CHECK_APPROX(z[4], x[4] * y[0] + 3 * x[3] * y[1] + 3 * x[2] * y[2] + x[1] * y[3]);
 
     y = tanh(x);
-    z = sinh(x)/cosh(x);
+    z = sinh(x) / cosh(x);
 
     CHECK_4TH_ORDER_REAL_NUMBERS(y, z);
 
     y = asinh(x);
-    z = 1/sqrt(x*x + 1);
+    z = 1 / sqrt(x * x + 1);
 
-    CHECK_APPROX( y[0], asinh(x[0]) );
-    CHECK_APPROX( y[1], z[0] );
-    CHECK_APPROX( y[2], z[1] );
-    CHECK_APPROX( y[3], z[2] );
-    CHECK_APPROX( y[4], z[3] );
+    CHECK_APPROX(y[0], asinh(x[0]));
+    CHECK_APPROX(y[1], z[0]);
+    CHECK_APPROX(y[2], z[1]);
+    CHECK_APPROX(y[3], z[2]);
+    CHECK_APPROX(y[4], z[3]);
 
-    y = acosh(10*x); // acosh requires x > 1
-    z = 1/sqrt(100*x*x - 1);
+    y = acosh(10 * x); // acosh requires x > 1
+    z = 1 / sqrt(100 * x * x - 1);
 
-    CHECK_APPROX( y[0], acosh(10*x[0]) );
-    CHECK_APPROX( y[1], z[0] );
-    CHECK_APPROX( y[2], z[1] );
-    CHECK_APPROX( y[3], z[2] );
-    CHECK_APPROX( y[4], z[3] );
+    CHECK_APPROX(y[0], acosh(10 * x[0]));
+    CHECK_APPROX(y[1], z[0]);
+    CHECK_APPROX(y[2], z[1]);
+    CHECK_APPROX(y[3], z[2]);
+    CHECK_APPROX(y[4], z[3]);
 
     y = atanh(x);
-    z = 1/(1 - x*x);
+    z = 1 / (1 - x * x);
 
-    CHECK_APPROX( y[0], atanh(x[0]) );
-    CHECK_APPROX( y[1], z[0] );
-    CHECK_APPROX( y[2], z[1] );
-    CHECK_APPROX( y[3], z[2] );
-    CHECK_APPROX( y[4], z[3] );
+    CHECK_APPROX(y[0], atanh(x[0]));
+    CHECK_APPROX(y[1], z[0]);
+    CHECK_APPROX(y[2], z[1]);
+    CHECK_APPROX(y[3], z[2]);
+    CHECK_APPROX(y[4], z[3]);
 
     //=====================================================================================================================
     //
@@ -394,20 +397,20 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
 
     y = abs(x);
 
-    CHECK_APPROX( y[0], std::abs(x[0]) );
-    CHECK_APPROX( y[1], std::abs(x[0])/x[0] * x[1] );
-    CHECK_APPROX( y[2], std::abs(x[0])/x[0] * x[2] );
-    CHECK_APPROX( y[3], std::abs(x[0])/x[0] * x[3] );
-    CHECK_APPROX( y[4], std::abs(x[0])/x[0] * x[4] );
+    CHECK_APPROX(y[0], std::abs(x[0]));
+    CHECK_APPROX(y[1], std::abs(x[0]) / x[0] * x[1]);
+    CHECK_APPROX(y[2], std::abs(x[0]) / x[0] * x[2]);
+    CHECK_APPROX(y[3], std::abs(x[0]) / x[0] * x[3]);
+    CHECK_APPROX(y[4], std::abs(x[0]) / x[0] * x[4]);
 
     y = -x;
     z = abs(y);
 
-    CHECK_APPROX( z[0], std::abs(y[0]) );
-    CHECK_APPROX( z[1], std::abs(y[0])/(y[0]) * y[1] );
-    CHECK_APPROX( z[2], std::abs(y[0])/(y[0]) * y[2] );
-    CHECK_APPROX( z[3], std::abs(y[0])/(y[0]) * y[3] );
-    CHECK_APPROX( z[4], std::abs(y[0])/(y[0]) * y[4] );
+    CHECK_APPROX(z[0], std::abs(y[0]));
+    CHECK_APPROX(z[1], std::abs(y[0]) / (y[0]) * y[1]);
+    CHECK_APPROX(z[2], std::abs(y[0]) / (y[0]) * y[2]);
+    CHECK_APPROX(z[3], std::abs(y[0]) / (y[0]) * y[3]);
+    CHECK_APPROX(z[4], std::abs(y[0]) / (y[0]) * y[4]);
 
     //=====================================================================================================================
     //
@@ -418,22 +421,38 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
     x = {0.5, 3.0, -5.0, -15.0, 11.0};
     y = {4.5, 3.0, -5.0, -15.0, 11.0};
 
-    z = min(x, y);    CHECK( z == x );
-    z = min(y, x);    CHECK( z == x );
-    z = min(x, 0.1);  CHECK( z == real4th(0.1) );
-    z = min(0.2, x);  CHECK( z == real4th(0.2) );
-    z = min(0.5, x);  CHECK( z == x );
-    z = min(x, 0.5);  CHECK( z == x );
-    z = min(3.5, x);  CHECK( z == x );
-    z = min(x, 3.5);  CHECK( z == x );
-    z = max(x, y);    CHECK( z == y );
-    z = max(y, x);    CHECK( z == y );
-    z = max(x, 0.1);  CHECK( z == x );
-    z = max(0.2, x);  CHECK( z == x );
-    z = max(0.5, x);  CHECK( z == x );
-    z = max(x, 0.5);  CHECK( z == x );
-    z = max(8.5, x);  CHECK( z == real4th(8.5) );
-    z = max(x, 8.5);  CHECK( z == real4th(8.5) );
+    z = min(x, y);
+    CHECK(z == x);
+    z = min(y, x);
+    CHECK(z == x);
+    z = min(x, 0.1);
+    CHECK(z == real4th(0.1));
+    z = min(0.2, x);
+    CHECK(z == real4th(0.2));
+    z = min(0.5, x);
+    CHECK(z == x);
+    z = min(x, 0.5);
+    CHECK(z == x);
+    z = min(3.5, x);
+    CHECK(z == x);
+    z = min(x, 3.5);
+    CHECK(z == x);
+    z = max(x, y);
+    CHECK(z == y);
+    z = max(y, x);
+    CHECK(z == y);
+    z = max(x, 0.1);
+    CHECK(z == x);
+    z = max(0.2, x);
+    CHECK(z == x);
+    z = max(0.5, x);
+    CHECK(z == x);
+    z = max(x, 0.5);
+    CHECK(z == x);
+    z = max(8.5, x);
+    CHECK(z == real4th(8.5));
+    z = max(x, 8.5);
+    CHECK(z == real4th(8.5));
 
     //=====================================================================================================================
     //
@@ -444,22 +463,22 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
     x = {0.5, 3.0, -5.0, -15.0, 11.0};
 
     // Check equality not only on value but also on the derivatives
-    CHECK( x == real4th({0.5, 3.0, -5.0, -15.0, 11.0}) );
+    CHECK(x == real4th({0.5, 3.0, -5.0, -15.0, 11.0}));
 
     // Check equality against plain numeric types (double) do not require check against derivatives
-    CHECK_FALSE( x == 0.6 );
-    CHECK( x == 0.5 );
+    CHECK_FALSE(x == 0.6);
+    CHECK(x == 0.5);
 
     // Check inequalities
-    CHECK_FALSE( x == real4th({0.5, 3.1, -5.0, -15.0, 11.0}) );
-    CHECK( x != real4th({0.5, 3.1, -5.0, -15.0, 11.0}) );
-    CHECK( x != 1.0 );
-    CHECK( x < 1.0 );
-    CHECK( x > 0.1 );
-    CHECK( x <= 1.0 );
-    CHECK( x >= 0.1 );
-    CHECK( x <= 0.5 );
-    CHECK( x >= 0.5 );
+    CHECK_FALSE(x == real4th({0.5, 3.1, -5.0, -15.0, 11.0}));
+    CHECK(x != real4th({0.5, 3.1, -5.0, -15.0, 11.0}));
+    CHECK(x != 1.0);
+    CHECK(x < 1.0);
+    CHECK(x > 0.1);
+    CHECK(x <= 1.0);
+    CHECK(x >= 0.1);
+    CHECK(x <= 0.5);
+    CHECK(x >= 0.5);
 
     //=====================================================================================================================
     //
@@ -467,9 +486,9 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
     //
     //=====================================================================================================================
 
-    CHECK_DERIVATIVES_REAL4TH_WRT( exp(log(2*x + 3*y)) );
-    CHECK_DERIVATIVES_REAL4TH_WRT( sin(2*x + 3*y) );
-    CHECK_DERIVATIVES_REAL4TH_WRT( exp(2*x + 3*y) * log(x/y) );
+    CHECK_DERIVATIVES_REAL4TH_WRT(exp(log(2 * x + 3 * y)));
+    CHECK_DERIVATIVES_REAL4TH_WRT(sin(2 * x + 3 * y));
+    CHECK_DERIVATIVES_REAL4TH_WRT(exp(2 * x + 3 * y) * log(x / y));
 
     // Testing array-unpacking of derivatives for real number
     {
@@ -477,11 +496,11 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
 
         auto [x0, x1, x2, x3, x4] = derivatives(x);
 
-        CHECK_APPROX( x0, x[0] );
-        CHECK_APPROX( x1, x[1] );
-        CHECK_APPROX( x2, x[2] );
-        CHECK_APPROX( x3, x[3] );
-        CHECK_APPROX( x4, x[4] );
+        CHECK_APPROX(x0, x[0]);
+        CHECK_APPROX(x1, x[1]);
+        CHECK_APPROX(x2, x[2]);
+        CHECK_APPROX(x3, x[3]);
+        CHECK_APPROX(x4, x[4]);
     }
 
     // Testing array-unpacking of derivatives for vector of real numbers
@@ -490,12 +509,24 @@ TEST_CASE("testing autodiff::real", "[forward][real]")
         real4th y = {{3.0, 4.0, 5.0, 6.0, 7.0}};
         real4th z = {{4.0, 5.0, 6.0, 7.0, 8.0}};
 
-        std::vector<real4th> u = { x, y, z };
+        std::vector<real4th> u = {x, y, z};
 
         auto [u0, u1, u2, u3, u4] = derivatives(u);
 
-        CHECK_APPROX( u0[0], x[0] ); CHECK_APPROX( u1[0], x[1] ); CHECK_APPROX( u2[0], x[2] ); CHECK_APPROX( u3[0], x[3] ); CHECK_APPROX( u4[0], x[4] );
-        CHECK_APPROX( u0[1], y[0] ); CHECK_APPROX( u1[1], y[1] ); CHECK_APPROX( u2[1], y[2] ); CHECK_APPROX( u3[1], y[3] ); CHECK_APPROX( u4[1], y[4] );
-        CHECK_APPROX( u0[2], z[0] ); CHECK_APPROX( u1[2], z[1] ); CHECK_APPROX( u2[2], z[2] ); CHECK_APPROX( u3[2], z[3] ); CHECK_APPROX( u4[2], z[4] );
+        CHECK_APPROX(u0[0], x[0]);
+        CHECK_APPROX(u1[0], x[1]);
+        CHECK_APPROX(u2[0], x[2]);
+        CHECK_APPROX(u3[0], x[3]);
+        CHECK_APPROX(u4[0], x[4]);
+        CHECK_APPROX(u0[1], y[0]);
+        CHECK_APPROX(u1[1], y[1]);
+        CHECK_APPROX(u2[1], y[2]);
+        CHECK_APPROX(u3[1], y[3]);
+        CHECK_APPROX(u4[1], y[4]);
+        CHECK_APPROX(u0[2], z[0]);
+        CHECK_APPROX(u1[2], z[1]);
+        CHECK_APPROX(u2[2], z[2]);
+        CHECK_APPROX(u3[2], z[3]);
+        CHECK_APPROX(u4[2], z[4]);
     }
 }


### PR DESCRIPTION
I worked on `real.hpp`. Nothing was fundamentally changed, more or less just formatting, refactoring, and extensive unit tests.

Important change: I removed `constexpr` from multiple overloads of `<cmath>` functions, e.g. `abs`, `min`, etc. See #275.