### PR TITLE
Improve and extend the Python API of `autodiff::real` types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(CCache)
 
 # Name and details of the project
-project(autodiff VERSION 1.0.0 LANGUAGES CXX)
+project(autodiff VERSION 1.0.1 LANGUAGES CXX)
 
 # Enable parallel build if MSVC is used
 add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)

--- a/python/bindings/real.py.cxx
+++ b/python/bindings/real.py.cxx
@@ -36,6 +36,7 @@
 // autodiff includes
 #include <autodiff/common/meta.hpp>
 #include <autodiff/forward/real/real.hpp>
+#include <autodiff/forward/utils/derivative.hpp>
 using namespace autodiff;
 using autodiff::detail::isSame;
 
@@ -172,6 +173,8 @@ void exportReal(py::module& m, const char* typestr)
     if constexpr (!isSame<T, float>) py::implicitly_convertible<float, Real<N, T>>();
     if constexpr (!isSame<T, double>) py::implicitly_convertible<double, Real<N, T>>();
 
+    m.def("seed", [](Real<N, T>& x) { x[1] = 1.0; });
+    m.def("unseed", [](Real<N, T>& x) { x[1] = 1.0; });
 
     m.def("abs"  , [](const Real<N, T>& x) { return abs(x); });
 

--- a/python/bindings/real.py.cxx
+++ b/python/bindings/real.py.cxx
@@ -70,6 +70,11 @@ void exportReal(py::module& m, const char* typestr)
         return self[0];
     };
 
+    auto __deepcopy__ = [](const Real<N, T>& self, py::object memo) -> Real<N, T>
+    {
+        return self;
+    };
+
     auto cls = py::class_<Real<N, T>>(m, typestr)
         .def(py::init<>())
         .def(py::init<const T&>())
@@ -80,6 +85,7 @@ void exportReal(py::module& m, const char* typestr)
         .def("__str__", __str__)
         .def("__repr__", __repr__)
         .def("__float__", __float__)
+        .def("__deepcopy__", __deepcopy__)  // needed when using autodiff::real types with plotly
 
         .def("exp", &autodiff::detail::exp<N, T>)
         .def("log", &autodiff::detail::log<N, T>)

--- a/python/package/autodiff/__init__.py
+++ b/python/package/autodiff/__init__.py
@@ -1,2 +1,12 @@
+from autodiff import autodiff4py
+
+def autodiff_number_format(self, spec):
+    return format(self.val(), spec)
+
+autodiff4py.real1st.__format__ = autodiff_number_format
+autodiff4py.real2nd.__format__ = autodiff_number_format
+autodiff4py.real3rd.__format__ = autodiff_number_format
+autodiff4py.real4th.__format__ = autodiff_number_format
+
 from autodiff.autodiff4py import *
 # from autodiff._extensions.some_module import *

--- a/python/package/autodiff/__init__.py
+++ b/python/package/autodiff/__init__.py
@@ -19,6 +19,26 @@ def _autodiff_number_format(self, spec):
 for numbertype in _autodiff_number_types:
     numbertype.__format__ = _autodiff_number_format
 
+# -------------------------------------------------------------------------------------
+# The code below is needed so that autodiff numbers can be used in plotly figures.
+# It teaches PlotlyJSONEncoder on how to encode an autodiff number to JSON.
+try:
+    from plotly.utils import PlotlyJSONEncoder
+    plotly_default = PlotlyJSONEncoder.default
+
+    def is_autodiff_number_type(o):
+        return any (t for t in _autodiff_number_types if isinstance(o, t))
+
+    def plotly_default_new(self, o):
+        if is_autodiff_number_type(o):
+            return o.val()
+        else:
+            return plotly_default(self, o)
+
+    PlotlyJSONEncoder.default = plotly_default_new
+except:
+    pass
+# -------------------------------------------------------------------------------------
 
 from autodiff.autodiff4py import *
 # from autodiff._extensions.some_module import *

--- a/python/package/autodiff/__init__.py
+++ b/python/package/autodiff/__init__.py
@@ -1,12 +1,24 @@
 from autodiff import autodiff4py
 
-def autodiff_number_format(self, spec):
+# List of all autodiff C++ number types exported to Python. Extend this as other
+# number types are exported!
+_autodiff_number_types = [
+    autodiff4py.real1st,
+    autodiff4py.real2nd,
+    autodiff4py.real3rd,
+    autodiff4py.real4th,
+]
+
+# -------------------------------------------------------------------------------------
+# Define the __format__ methods for all autodiff number types. This is needed so
+# that we can write formatted strings such as f"{x:.3f}" and avoid a Python
+# runtime error.
+def _autodiff_number_format(self, spec):
     return format(self.val(), spec)
 
-autodiff4py.real1st.__format__ = autodiff_number_format
-autodiff4py.real2nd.__format__ = autodiff_number_format
-autodiff4py.real3rd.__format__ = autodiff_number_format
-autodiff4py.real4th.__format__ = autodiff_number_format
+for numbertype in _autodiff_number_types:
+    numbertype.__format__ = _autodiff_number_format
+
 
 from autodiff.autodiff4py import *
 # from autodiff._extensions.some_module import *


### PR DESCRIPTION
This PR introduces the following new methods to the Python API of `autodiff::real` number types:

- `autodiff.seed(x: autodiff.real)`
- `autodiff.unseed(x: autodiff.real)`
- `autodiff.__format__` (to permit Python formatted strings such as `f"{x:.3f}"` where `x` is `real`
- `autodiff.__deepcopy__` (to permit the use of autodiff numbers in plotly plots