### PR TITLE
Adds ::reverse namespace to avoid clash with forward

### DIFF
--- a/autodiff/reverse/var/eigen.hpp
+++ b/autodiff/reverse/var/eigen.hpp
@@ -7,7 +7,7 @@
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 //
-// Copyright (c) 2018-2022 Allan Leal
+// Copyright © 2018-2024 Allan Leal
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/autodiff/reverse/var/eigen.hpp
+++ b/autodiff/reverse/var/eigen.hpp
@@ -7,7 +7,7 @@
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 //
-// Copyright © 2018–2024 Allan Leal
+// Copyright (c) 2018-2022 Allan Leal
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -76,7 +76,7 @@ struct ScalarBinaryOpTraits<T, autodiff::Variable<T>, BinOp>
 };
 
 template<typename T>
-struct NumTraits<autodiff::detail::ExprPtr<T>> : NumTraits<T> // permits to get the epsilon, dummy_precision, lowest, highest functions
+struct NumTraits<autodiff::reverse::detail::ExprPtr<T>> : NumTraits<T> // permits to get the epsilon, dummy_precision, lowest, highest functions
 {
     typedef autodiff::Variable<T> Real;
     typedef autodiff::Variable<T> NonInteger;
@@ -94,13 +94,13 @@ struct NumTraits<autodiff::detail::ExprPtr<T>> : NumTraits<T> // permits to get 
 };
 
 template<typename T, typename BinOp>
-struct ScalarBinaryOpTraits<autodiff::detail::ExprPtr<T>, T, BinOp>
+struct ScalarBinaryOpTraits<autodiff::reverse::detail::ExprPtr<T>, T, BinOp>
 {
     typedef autodiff::Variable<T> ReturnType;
 };
 
 template<typename T, typename BinOp>
-struct ScalarBinaryOpTraits<T, autodiff::detail::ExprPtr<T>, BinOp>
+struct ScalarBinaryOpTraits<T, autodiff::reverse::detail::ExprPtr<T>, BinOp>
 {
     typedef autodiff::Variable<T> ReturnType;
 };
@@ -108,6 +108,7 @@ struct ScalarBinaryOpTraits<T, autodiff::detail::ExprPtr<T>, BinOp>
 } // namespace Eigen
 
 namespace autodiff {
+namespace reverse {
 namespace detail {
 
 template<typename T, int Rows, int MaxRows>
@@ -214,10 +215,12 @@ auto hessian(const Variable<T>& y, Eigen::DenseBase<X>& x)
 }
 
 } // namespace detail
+  //
+} // namespace reverse
 
 AUTODIFF_DEFINE_EIGEN_TYPEDEFS_ALL_SIZES(autodiff::var, var)
 
-using detail::gradient;
-using detail::hessian;
+using reverse::detail::gradient;
+using reverse::detail::hessian;
 
 } // namespace autodiff

--- a/autodiff/reverse/var/eigen.hpp
+++ b/autodiff/reverse/var/eigen.hpp
@@ -7,7 +7,7 @@
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 //
-// Copyright © 2018-2024 Allan Leal
+// Copyright © 2018–2024 Allan Leal
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/autodiff/reverse/var/var.hpp
+++ b/autodiff/reverse/var/var.hpp
@@ -7,7 +7,7 @@
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 //
-// Copyright (c) 2018-2022 Allan Leal
+// Copyright © 2018-2024 Allan Leal
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/autodiff/reverse/var/var.hpp
+++ b/autodiff/reverse/var/var.hpp
@@ -7,7 +7,7 @@
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 //
-// Copyright © 2018–2024 Allan Leal
+// Copyright (c) 2018-2022 Allan Leal
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -46,11 +46,13 @@
 namespace autodiff {}
 
 namespace autodiff {
-namespace detail {
-
+// avoid clash with autodiff::detail in autodiff/forward/dual/dual.hpp
+namespace reverse {
 using detail::Requires;
 using detail::For;
 using detail::isArithmetic;
+namespace detail {
+
 
 using std::abs;
 using std::acos;
@@ -1524,13 +1526,15 @@ using HigherOrderVariable = typename AuxHigherOrderVariable<N, T>::type;
 
 } // namespace detail
 
-using detail::wrt;
-using detail::derivatives;
-using detail::Variable;
-using detail::val;
+} // namespace reverse
+
+using reverse::detail::wrt;
+using reverse::detail::derivatives;
+using reverse::detail::Variable;
+using reverse::detail::val;
 
 using var = Variable<double>;
 
-inline detail::BooleanExpr boolref(const bool& v) { return detail::BooleanExpr([&]() { return v; }); }
+inline reverse::detail::BooleanExpr boolref(const bool& v) { return reverse::detail::BooleanExpr([&]() { return v; }); }
 
 } // namespace autodiff

--- a/autodiff/reverse/var/var.hpp
+++ b/autodiff/reverse/var/var.hpp
@@ -7,7 +7,7 @@
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 //
-// Copyright © 2018-2024 Allan Leal
+// Copyright © 2018–2024 Allan Leal
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Fixes https://github.com/autodiff/autodiff/issues/179

Changes the ::detaill to ::reverse::detail namespace in reverse/var/*.hpp so that forward and reverse can be included in the same compilation unit. 

For example, now this minimal example compiles:

```cpp
#include <autodiff/forward/dual.hpp>
#include <autodiff/forward/real.hpp>
#include <autodiff/reverse/var.hpp>
int main() { return 0; }
```