### PR TITLE
Make the default constructor for Dual constexpr

### DIFF
--- a/autodiff/forward/dual/dual.hpp
+++ b/autodiff/forward/dual/dual.hpp
@@ -512,7 +512,7 @@ struct Dual
 
     G grad = {};
 
-    AUTODIFF_DEVICE_FUNC Dual()
+    AUTODIFF_DEVICE_FUNC constexpr Dual()
     {}
 
     template<typename U, Requires<isExpr<U> || isArithmetic<U>> = true>

--- a/tests/forward/dual/dual.test.cu
+++ b/tests/forward/dual/dual.test.cu
@@ -311,6 +311,13 @@ void ternary(const FromA & fromA, const FromB & fromB, const FromC & fromC, To &
     CHECK(dfdyyy[3] == approx(val(uyyy)));                                                      \
 }
 
+// Ensure Dual can be used with CUDA variable memory space specifiers (must be
+// default-constructible at compile time).
+__device__ dual x_device;
+__shared__ dual x_shared;
+__constant__ dual x_const;
+__managed__ dual x_managed;
+
 TEST_CASE("testing autodiff::dual", "[forward][dual][cuda]")
 {
     dual x;

--- a/tests/forward/real/real.test.cu
+++ b/tests/forward/real/real.test.cu
@@ -168,6 +168,13 @@ void ternary(const FromA& fromA, const FromB& fromB, const FromC& fromC, To& to,
     CHECK_APPROX(dfdv[4], u[4]);                                                                     \
 }
 
+// Ensure Real can be used with CUDA variable memory space specifiers (must be
+// default-constructible at compile time).
+__device__ real4th x_device;
+__shared__ real4th x_shared;
+__constant__ real4th x_const;
+__managed__ real4th x_managed;
+
 // Auxiliary constants
 #define ln10 (2.302585092994046)
 #define pi (3.14159265359)


### PR DESCRIPTION
This is needed for global variables with CUDA memory space specifiers (`__device__`, `__shared__`, `__constant__`, and `__managed__`).