### PR TITLE
Fix wrong shape in matrix export

### DIFF
--- a/python/bindings/eigen.hxx
+++ b/python/bindings/eigen.hxx
@@ -234,7 +234,7 @@ void exportMatrix(py::module& m, const char* typestr)
     cls.def(py::self != py::self);
 
     cls.def("asarray", [](const Mat& s) {
-        py::tuple shape = py::make_tuple(s.rows(), s.cols());
+        py::array_t<double>::ShapeContainer shape = {s.rows(), s.cols()};
         py::array_t<double> res(shape);
         auto data = res.mutable_data();
         auto k = 0;

--- a/python/bindings/eigen.hxx
+++ b/python/bindings/eigen.hxx
@@ -238,8 +238,8 @@ void exportMatrix(py::module& m, const char* typestr)
         py::array_t<double> res(shape);
         auto data = res.mutable_data();
         auto k = 0;
-        for(auto j = 0; j < s.cols(); ++j)
-            for(auto i = 0; i < s.rows(); ++i)
+        for(auto i = 0; i < s.rows(); ++i)
+            for(auto j = 0; j < s.cols(); ++j)
                 data[k++] = autodiff::val(s(i, j));
         return res;
     });


### PR DESCRIPTION
Tuple is a wrong type for shape and array is stripped with it. The ShapeContainer should be used.