### PR TITLE
Add support for Eigen 5

### DIFF
--- a/autodiff/common/eigen.hpp
+++ b/autodiff/common/eigen.hpp
@@ -99,7 +99,27 @@ struct VectorTraits<Eigen::VectorBlock<VectorType, Size>>
     using ReplaceValueType = VectorReplaceValueType<VectorType, NewValueType>;
 };
 
-#if EIGEN_VERSION_AT_LEAST(3, 3, 90)
+#if EIGEN_VERSION_AT_LEAST(5, 0, 0)
+
+    template<typename VectorType, typename IndicesType, Eigen::Index V>
+    struct VectorTraits<Eigen::IndexedView<VectorType, IndicesType, Eigen::internal::SingleRange<V>>>
+    {
+        using ValueType = typename PlainType<VectorType>::Scalar;
+
+        template<typename NewValueType>
+        using ReplaceValueType = VectorReplaceValueType<VectorType, NewValueType>;
+    };
+
+    template<typename VectorType, typename IndicesType, Eigen::Index V>
+    struct VectorTraits<Eigen::IndexedView<VectorType, Eigen::internal::SingleRange<V>, IndicesType>>
+    {
+        using ValueType = typename PlainType<VectorType>::Scalar;
+
+        template<typename NewValueType>
+        using ReplaceValueType = VectorReplaceValueType<VectorType, NewValueType>;
+    };
+
+#elif EIGEN_VERSION_AT_LEAST(3, 3, 90)
 
     template<typename VectorType, typename IndicesType>
     struct VectorTraits<Eigen::IndexedView<VectorType, IndicesType, Eigen::internal::SingleRange>>

--- a/autodiff/common/meta.hpp
+++ b/autodiff/common/meta.hpp
@@ -36,7 +36,7 @@
 
 #ifndef AUTODIFF_DEVICE_FUNC
 #ifdef AUTODIFF_EIGEN_FOUND
-    #include <Eigen/src/Core/util/Macros.h>
+    #include <Eigen/Core>
     #define AUTODIFF_DEVICE_FUNC EIGEN_DEVICE_FUNC
 #else
     #define AUTODIFF_DEVICE_FUNC


### PR DESCRIPTION
  #392

  Changes

  - autodiff/common/meta.hpp: Replace #include <Eigen/src/Core/util/Macros.h> with #include <Eigen/Core>. Eigen 5 forbids direct includes of internal headers.
  - autodiff/common/eigen.hpp: Add EIGEN_VERSION_AT_LEAST(5, 0, 0) branch for VectorTraits<IndexedView<..., SingleRange, ...>> specializations. Eigen::internal::SingleRange changed from a plain class to a class
  template in Eigen 5.